### PR TITLE
Add components for dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Components for alerts, badges, and links
 - Components for breadcrumb and navigation
 - Components for buttons, groups, and toolbars
+- Components for dropdowns
 - Components for forms and their fields including feedback
 - Components for list groups and their items

--- a/README.md
+++ b/README.md
@@ -155,6 +155,31 @@ Button groups can be grouped into a [toolbar](https://getbootstrap.com/docs/5.3/
 </x-bs:toolbar>
 ```
 
+### Dropdowns
+[Dropdown buttons](https://getbootstrap.com/docs/5.3/components/dropdowns/#single-button) can be added as follows:
+
+```HTML
+<x-bs::dropdown.button direction="end" variant="secondary">
+    My button
+    <x-slot:dropdown>
+        <x-bs::dropdown.item href="#">Item 1</x-bs::dropdown.item>
+        <x-bs::dropdown.item href="#">Item 2</x-bs::dropdown.item>
+    </x-slot:dropdown>
+</x-bs::dropdown.button>
+```
+
+The `direction` attribute can be used to set the direction of the dropdown overlay. It defaults to `down`.
+`variant` (default `primary`) is inherited from the [button component](#buttons).
+
+Within the `<x-slot:dropdown>` you may place [headers](https://getbootstrap.com/docs/5.3/components/dropdowns/#headers) 
+and [items](https://getbootstrap.com/docs/5.3/components/dropdowns/#menu-items):
+```HTML
+<x-bs::dropdown.header>My header</x-bs::dropdown.header>
+<x-bs::dropdown.item href="#">Item</x-bs::dropdown.item>
+```
+
+Note that Bootstrap's dropdowns require Popper, which needs to be included separately if you don't use Bootstrap's `bootstrap.bundle.min.js`.
+
 ### Forms
 Use `<x-bs::form>` to create [forms](https://getbootstrap.com/docs/5.3/forms/overview/) (method defaults to `POST`),
 any additional attributes passed to the form component will be outputted as well:
@@ -307,3 +332,13 @@ Items can be added via `<x-bs::list.item>`:
 `<x-bs::nav>` creates a [nav](https://getbootstrap.com/docs/5.3/components/navs-tabs/) container, use `container="ol"` to change the container element from the default `<ul>` to `<ol>`.
 
 Navigation items can be added via `<x-bs::nav.item href="{{ route('route-name') }}">Current Page</x-bs::nav.item>`.
+
+A navigation item may open a [dropdown](#dropdowns) if you enabled this by adding a dropdown slot:
+```HTML
+<x-bs::nav.item id="navbarUserDropdown">
+    Dropdown link text
+    <x-slot:dropdown class="dropdown-menu-end">
+        <!-- dropdown content-->
+    </x-slot:dropdown>
+</x-bs::list.item>
+```

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -20,10 +20,7 @@
 
     <!-- Increase line limit for test files due to long sample strings -->
     <rule ref="Generic.Files.LineLength">
-        <include-pattern>*/tests/*</include-pattern>
-        <properties>
-            <property name="lineLimit" value="160"/>
-        </properties>
+        <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
 
     <!-- Check vor PHP compatibility -->

--- a/resources/views/components/dropdown/button.blade.php
+++ b/resources/views/components/dropdown/button.blade.php
@@ -1,0 +1,35 @@
+@props([
+    /**
+     * @var string $direction
+     * Possible values: down, down-center, up, up-center, start, end
+     */
+    'direction' => 'down',
+])
+@php
+    /** @var \Illuminate\View\ComponentAttributeBag $attributes */
+    /** @var ?\Illuminate\View\ComponentSlot $dropdown */
+
+    $containerClass = 'drop' . $direction;
+@endphp
+<div @class($containerClass)>
+    <x-bs::button :attributes="$attributes
+        ->class([
+            'dropdown-toggle',
+        ])
+        ->merge([
+            'type' => 'button',
+            'data-bs-toggle' => 'dropdown',
+            'aria-expanded' => 'false',
+        ])">{{ $slot }}</x-bs::button>
+    @isset($dropdown)
+        <ul {{ $dropdown->attributes
+            ->class([
+                'dropdown-menu',
+            ])
+            ->merge([
+                'aria-labelledby' => $attributes->get('id'),
+            ]) }}>
+            {{ $dropdown }}
+        </ul>
+    @endisset
+</div>

--- a/resources/views/components/dropdown/header.blade.php
+++ b/resources/views/components/dropdown/header.blade.php
@@ -1,0 +1,4 @@
+<li {{ $attributes
+    ->class([
+        'dropdown-header',
+    ]) }}>{{ $slot }}</li>

--- a/resources/views/components/dropdown/item.blade.php
+++ b/resources/views/components/dropdown/item.blade.php
@@ -2,12 +2,18 @@
     'isSubItem' => false,
     'subItems' => false,
 ])
+@php
+    $active = $attributes->get('href') === request()?->fullUrl();
+@endphp
 <li>{{-- no whitespace
 --}}<a {{ $attributes
         ->class([
             'dropdown-item',
-            'active' => $attributes->get('href') === request()->fullUrl(),
-        ]) }}>{{-- no whitespace
+            'active' => $active,
+        ])
+        ->merge([
+            'aria-current' => $active ? 'true' : null,
+        ])}}>{{-- no whitespace
     --}}@if($isSubItem){{-- no whitespace
             --}}<span class="ms-4">{{ $slot }}</span>{{-- no whitespace
         --}}@else{{-- no whitespace

--- a/resources/views/components/dropdown/item.blade.php
+++ b/resources/views/components/dropdown/item.blade.php
@@ -1,0 +1,22 @@
+@props([
+    'isSubItem' => false,
+    'subItems' => false,
+])
+<li>{{-- no whitespace
+--}}<a {{ $attributes
+        ->class([
+            'dropdown-item',
+            'active' => $attributes->get('href') === request()->fullUrl(),
+        ]) }}>{{-- no whitespace
+    --}}@if($isSubItem){{-- no whitespace
+            --}}<span class="ms-4">{{ $slot }}</span>{{-- no whitespace
+        --}}@else{{-- no whitespace
+            --}}{{ $slot }}{{-- no whitespace
+    --}}@endif{{-- no whitespace
+--}}</a>{{-- no whitespace
+--}}@if($subItems)
+        <ul class="list-unstyled small">
+            {{ $subItems }}
+        </ul>
+    @endif
+</li>

--- a/resources/views/components/nav/item.blade.php
+++ b/resources/views/components/nav/item.blade.php
@@ -8,16 +8,42 @@
     $itemAttributes = $attributes->whereDoesntStartWith('container-');
 
     $active = $attributes->get('href') === request()?->fullUrl();
+
+    /** @var ?\Illuminate\View\ComponentSlot $dropdown */
+    $hasDropdown = isset($dropdown);
+    if ($hasDropdown) {
+        $itemAttributes = $itemAttributes->merge([
+            'href' => $itemAttributes->get('href', '#'),
+            'role' => 'button',
+            'data-bs-toggle' => 'dropdown',
+            'aria-haspopup' => 'true',
+            'aria-expanded' => 'false',
+        ]);
+    }
 @endphp
-<li {{ $containerAttributes->class(['nav-item']) }}>
+<li {{ $containerAttributes
+    ->class([
+        'nav-item',
+        'dropdown' => $hasDropdown,
+    ]) }}>
     <a {{ $itemAttributes
         ->class([
             'nav-link',
             'active' => $active,
+            'dropdown-toggle' => $hasDropdown,
         ])
         ->merge([
             'aria-current' => $active ? 'page' : null,
             'aria-disabled' => $disabled ? 'true' : null,
             'disabled' => $disabled,
         ]) }}>{{ $slot }}</a>
+    @if($hasDropdown)
+        <ul {{ $dropdown->attributes
+            ->class([
+                'dropdown-menu',
+            ])
+            ->merge([
+                'aria-labelledby' => $itemAttributes->get('id'),
+            ]) }}>{{ $dropdown }}</ul>
+    @endif
 </li>

--- a/resources/views/components/nav/item.blade.php
+++ b/resources/views/components/nav/item.blade.php
@@ -1,6 +1,13 @@
 @props([
     /** @var bool $disabled */
     'disabled' => false,
+
+    /**
+     * @var string $direction
+     * Possible values: down, down-center, up, up-center, start, end
+     * May be used only in combination with dropdown slot.
+     */
+    'direction' => 'down',
 ])
 @php
     /** @var \Illuminate\View\ComponentAttributeBag $attributes */
@@ -24,7 +31,7 @@
 <li {{ $containerAttributes
     ->class([
         'nav-item',
-        'dropdown' => $hasDropdown,
+        'drop' . $direction => $hasDropdown,
     ]) }}>
     <a {{ $itemAttributes
         ->class([

--- a/tests/Feature/Dropdown/DropdownButtonTest.php
+++ b/tests/Feature/Dropdown/DropdownButtonTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Portavice\Bladestrap\Tests\Feature\Dropdown;
+
+use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
+use Portavice\Bladestrap\Tests\Traits\TestsVariants;
+
+class DropdownButtonTest extends ComponentTestCase
+{
+    use TestsVariants;
+
+    /**
+     * @dataProvider variants
+     */
+    public function testDropdownButtonRendersCorrectly(string $buttonClass, ?string $variant): void
+    {
+        $this->assertBladeRendersToHtml(
+            '<div class="dropdown">
+                <button class="btn ' . $buttonClass . ' dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">My button</button>
+                <ul class="dropdown-menu">
+                    <li><a class="dropdown-item" href="http://localhost/test1">Test1</a></li>
+                    <li><a class="dropdown-item" href="http://localhost/test2">Test2</a></li>
+                </ul>
+            </div>',
+            $this->bladeView(
+                sprintf(
+                    '<x-bs::dropdown.button %s>
+                        My button
+                        <x-slot:dropdown>
+                            <x-bs::dropdown.item href="http://localhost/test1">Test1</x-bs::dropdown.item>
+                            <x-bs::dropdown.item href="http://localhost/test2">Test2</x-bs::dropdown.item>
+                        </x-slot:dropdown>
+                    </x-bs::dropdown.button>',
+                    self::makeVariantAttribute($variant)
+                )
+            )
+        );
+    }
+
+    public static function variants(): array
+    {
+        return [
+            ['btn-primary', null],
+            ...self::makeDataProvider('btn-'),
+        ];
+    }
+
+    public function testDropdownButtonReferencesDropdownMenu(): void
+    {
+        $this->assertBladeRendersToHtml(
+            '<div class="dropdown">
+                <button class="btn btn-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false" id="dropdown-button-link">My button</button>
+                <ul aria-labelledby="dropdown-button-link" class="dropdown-menu">
+                    ...
+                </ul>
+            </div>',
+            $this->bladeView('<x-bs::dropdown.button id="dropdown-button-link">
+                    My button
+                    <x-slot:dropdown>
+                        ...
+                    </x-slot:dropdown>
+                </x-bs::dropdown.button>')
+        );
+    }
+
+    /**
+     * @dataProvider directions
+     */
+    public function testDropdownButtonWithDirectionRendersCorrectly(string $containerClass, ?string $direction): void
+    {
+        $this->assertBladeRendersToHtml(
+            '<div class="' . $containerClass . '">
+                <button class="btn btn-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">My button</button>
+                <ul class="dropdown-menu">
+                    <li><a class="dropdown-item" href="http://localhost/test1">Test1</a></li>
+                    <li><a class="dropdown-item" href="http://localhost/test2">Test2</a></li>
+                </ul>
+            </div>',
+            $this->bladeView(
+                sprintf(
+                    '<x-bs::dropdown.button %s>
+                        My button
+                        <x-slot:dropdown>
+                            <x-bs::dropdown.item href="http://localhost/test1">Test1</x-bs::dropdown.item>
+                            <x-bs::dropdown.item href="http://localhost/test2">Test2</x-bs::dropdown.item>
+                        </x-slot:dropdown>
+                    </x-bs::dropdown.button>',
+                    isset($direction)
+                        ? sprintf('direction="%s"', $direction)
+                        : ''
+                )
+            )
+        );
+    }
+
+    public static function directions(): array
+    {
+        return [
+            ['dropdown', null],
+            ['dropdown', 'down'],
+            ['dropdown-center', 'down-center'],
+            ['dropup', 'up'],
+            ['dropup-center', 'up-center'],
+            ['dropstart', 'start'],
+            ['dropend', 'end'],
+        ];
+    }
+}

--- a/tests/Feature/Dropdown/DropdownHeaderTest.php
+++ b/tests/Feature/Dropdown/DropdownHeaderTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Portavice\Bladestrap\Tests\Feature\Dropdown;
+
+use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
+
+class DropdownHeaderTest extends ComponentTestCase
+{
+    public function testDropdownHeaderRendersCorrectly(): void
+    {
+        $this->assertBladeRendersToHtml(
+            '<li class="dropdown-header">My header</li>',
+            $this->bladeView('<x-bs::dropdown.header>My header</x-bs::dropdown.header>')
+        );
+    }
+}

--- a/tests/Feature/Dropdown/DropdownItemTest.php
+++ b/tests/Feature/Dropdown/DropdownItemTest.php
@@ -18,7 +18,7 @@ class DropdownItemTest extends ComponentTestCase
     {
         $this->mockRequest('http://localhost/my-account');
         $this->assertBladeRendersToHtml(
-            '<li><a class="dropdown-item active" href="http://localhost/my-account">My account</a></li>',
+            '<li><a aria-current="true" class="dropdown-item active" href="http://localhost/my-account">My account</a></li>',
             $this->bladeView('<x-bs::dropdown.item href="http://localhost/my-account">My account</x-bs::dropdown.item>')
         );
     }

--- a/tests/Feature/Dropdown/DropdownItemTest.php
+++ b/tests/Feature/Dropdown/DropdownItemTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Portavice\Bladestrap\Tests\Feature\Dropdown;
+
+use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
+
+class DropdownItemTest extends ComponentTestCase
+{
+    public function testDropdownItemRendersCorrectly(): void
+    {
+        $this->assertBladeRendersToHtml(
+            '<li><a class="dropdown-item" href="http://localhost/my-account">My account</a></li>',
+            $this->bladeView('<x-bs::dropdown.item href="http://localhost/my-account">My account</x-bs::dropdown.item>')
+        );
+    }
+
+    public function testActiveDropdownItemRendersCorrectly(): void
+    {
+        $this->mockRequest('http://localhost/my-account');
+        $this->assertBladeRendersToHtml(
+            '<li><a class="dropdown-item active" href="http://localhost/my-account">My account</a></li>',
+            $this->bladeView('<x-bs::dropdown.item href="http://localhost/my-account">My account</x-bs::dropdown.item>')
+        );
+    }
+
+    public function testDropdownItemWithSubItemsRendersCorrectly(): void
+    {
+        $this->assertBladeRendersToHtml(
+            '<li><a class="dropdown-item" href="http://localhost/my-account">My account</a> ' .
+            '<ul class="list-unstyled small">
+                    <li><a class="dropdown-item" href="http://localhost/my-account/orders"><span class="ms-4">My orders</span></a></li>
+                    <li><a class="dropdown-item" href="http://localhost/my-account/invoices"><span class="ms-4">My invoices</span></a></li>
+                </ul>
+            </li>',
+            $this->bladeView(
+                '<x-bs::dropdown.item href="http://localhost/my-account">
+                    My account
+                    <x-slot name="subItems">
+                        <li><a class="dropdown-item" href="http://localhost/my-account/orders"><span class="ms-4">My orders</span></a></li>
+                        <li><a class="dropdown-item" href="http://localhost/my-account/invoices"><span class="ms-4">My invoices</span></a></li>
+                    </x-slot>
+                </x-bs::dropdown.item>'
+            )
+        );
+    }
+
+    public function testDropdownSubItemRendersCorrectly(): void
+    {
+        $this->assertBladeRendersToHtml(
+            '<li><a class="dropdown-item" href="http://localhost/my-account/orders"><span class="ms-4">My orders</span></a></li>',
+            $this->bladeView('<x-bs::dropdown.item href="http://localhost/my-account/orders" :isSubItem="true">My orders</x-bs::dropdown.item>')
+        );
+    }
+}

--- a/tests/Feature/NavTest.php
+++ b/tests/Feature/NavTest.php
@@ -38,4 +38,20 @@ class NavTest extends ComponentTestCase
             $this->bladeView('<x-bs::nav.item href="http://localhost/current-page">Current Page</x-bs::nav.item>')
         );
     }
+
+    public function testNavDropdownRendersCorrectly(): void
+    {
+        $this->assertBladeRendersToHtml(
+            '<li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="myDropdownLink">Dropdown title</a>
+                <ul  aria-labelledby="myDropdownLink" class="dropdown-menu dropdown-menu-end"><li><a class="dropdown-item" href="#">Action</a></li></ul>
+            </li>',
+            $this->bladeView('<x-bs::nav.item id="myDropdownLink">
+                Dropdown title
+                <x-slot:dropdown class="dropdown-menu-end">
+                      <li><a class="dropdown-item" href="#">Action</a></li>
+                </x-slot:dropdown>
+            </x-bs::nav.item>')
+        );
+    }
 }


### PR DESCRIPTION
Includes an extension of `<x-bs::nav.item>` to enable dropdown behavior for navigation items.