### PR TITLE
Fix missing boolean attributes for checkboxes, radios, selects

### DIFF
--- a/resources/views/components/form/field.blade.php
+++ b/resources/views/components/form/field.blade.php
@@ -151,7 +151,7 @@
                                     'role' => $role,
                                     'type' => $type,
                                     'value' => $optionValue,
-                                ]) }} @checked(ValueHelper::isActive($optionValue, $value))/>
+                                ]) }} @checked(ValueHelper::isActive($optionValue, $value)) @disabled($disabled) @readonly($readonly) @required($required)/>
                             <label @class([
                                 'form-check-label',
                             ]) for="{{ $optionId }}">{{ $optionLabel }}</label>
@@ -187,7 +187,7 @@
                     ->merge([
                         'id' => $id ?? $name,
                         'name' => $name,
-                    ]) }} @disabled($disabled) @required($required)>
+                    ]) }} @disabled($disabled) @readonly($readonly) @required($required)>
                     @foreach($options as $optionValue => $description)
                         <option {{ $getAttributesForOption($optionValue)
                             ->merge([

--- a/tests/Feature/Form/FormField/FormFieldTest.php
+++ b/tests/Feature/Form/FormField/FormFieldTest.php
@@ -3,9 +3,12 @@
 namespace Portavice\Bladestrap\Tests\Feature\Form\FormField;
 
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
+use Portavice\Bladestrap\Tests\Traits\TestsBooleanAttributes;
 
 class FormFieldTest extends ComponentTestCase
 {
+    use TestsBooleanAttributes;
+
     public function testFormFieldRendersCorrectly(): void
     {
         $this->assertBladeRendersToHtml(
@@ -82,6 +85,20 @@ class FormFieldTest extends ComponentTestCase
                 <x-slot:prependText>≥</x-slot>
                 <x-slot:appendText>€</x-slot>
             </x-bs::form.field>'
+        );
+    }
+
+    /**
+     * @dataProvider booleanFormFieldAttributes
+     */
+    public function testFormFieldWithBooleanAttributesRendersCorrectly(string $html, string $blade): void
+    {
+        $this->assertBladeRendersToHtml(
+            '<div class="mb-3">
+                <label for="first_name" class="form-label">First name</label>
+                <input id="first_name" name="first_name" type="text" value="Patrick" class="form-control" '. $html . '/>
+            </div>',
+            '<x-bs::form.field name="first_name" type="text" value="Patrick" ' . $blade . '>First name</x-bs::form.field>'
         );
     }
 }

--- a/tests/Feature/Form/FormField/Type/CheckboxTest.php
+++ b/tests/Feature/Form/FormField/Type/CheckboxTest.php
@@ -4,9 +4,12 @@ namespace Portavice\Bladestrap\Tests\Feature\Form\FormField\Type;
 
 use Portavice\Bladestrap\Support\OptionCollection;
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
+use Portavice\Bladestrap\Tests\Traits\TestsBooleanAttributes;
 
 class CheckboxTest extends ComponentTestCase
 {
+    use TestsBooleanAttributes;
+
     /**
      * @dataProvider checkBoxTypes
      */
@@ -164,6 +167,42 @@ class CheckboxTest extends ComponentTestCase
                         1 => 'Option enabled',
                     ],
                     'value' => 0,
+                ]
+            )
+        );
+    }
+
+    /**
+     * @dataProvider booleanFormFieldAttributes
+     */
+    public function testFormFieldWithBooleanAttributesRendersCorrectly(string $html, string $blade): void
+    {
+        $this->assertBladeRendersToHtml(
+            '<div class="mb-3">
+                <label for="my_model" class="form-label">My Model</label>
+                <div class="form-check">
+                    <input id="my_model-1" name="my_models[]" type="checkbox" value="1" class="form-check-input" ' . $html . '/>
+                    <label class="form-check-label" for="my_model-1">A</label>
+                </div>
+                <div class="form-check">
+                    <input id="my_model-2" name="my_models[]" type="checkbox" value="2" class="form-check-input" checked ' . $html . '/>
+                    <label class="form-check-label" for="my_model-2">B</label>
+                </div>
+                <div class="form-check">
+                    <input id="my_model-3" name="my_models[]" type="checkbox" value="3" class="form-check-input" checked ' . $html . '/>
+                    <label class="form-check-label" for="my_model-3">C</label>
+                </div>
+            </div>',
+            $this->bladeView(
+                '<x-bs::form.field id="my_model" name="my_models[]" type="checkbox"
+                                         :options="$options" :value="$value" cast="int" ' . $blade . '>My Model</x-bs::form.field>',
+                data: [
+                    'options' => [
+                        1 => 'A',
+                        2 => 'B',
+                        3 => 'C',
+                    ],
+                    'value' => [2, 3],
                 ]
             )
         );

--- a/tests/Feature/Form/FormField/Type/RadioTest.php
+++ b/tests/Feature/Form/FormField/Type/RadioTest.php
@@ -4,9 +4,12 @@ namespace Portavice\Bladestrap\Tests\Feature\Form\FormField\Type;
 
 use Portavice\Bladestrap\Support\OptionCollection;
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
+use Portavice\Bladestrap\Tests\Traits\TestsBooleanAttributes;
 
 class RadioTest extends ComponentTestCase
 {
+    use TestsBooleanAttributes;
+
     public function testRadioRendersCorrectly(): void
     {
         $expectedHtml = '<div class="mb-3">
@@ -80,6 +83,41 @@ class RadioTest extends ComponentTestCase
                         },
                     ]),
                     'value' => 1,
+                ]
+            )
+        );
+    }
+
+    /**
+     * @dataProvider booleanFormFieldAttributes
+     */
+    public function testRadioWithBooleanAttributesRendersCorrectly(string $html, string $blade): void
+    {
+        $this->assertBladeRendersToHtml(
+            '<div class="mb-3">
+                <label for="my_model" class="form-label">My Model</label>
+                <div class="form-check">
+                    <input id="my_model-1" name="my_model" type="radio" value="1" class="form-check-input" ' . $html . '/>
+                    <label class="form-check-label" for="my_model-1">A</label>
+                </div>
+                <div class="form-check">
+                    <input id="my_model-2" name="my_model" type="radio" value="2" class="form-check-input" checked ' . $html . '/>
+                    <label class="form-check-label" for="my_model-2">B</label>
+                </div>
+                <div class="form-check">
+                    <input id="my_model-3" name="my_model" type="radio" value="3" class="form-check-input" ' . $html . '/>
+                    <label class="form-check-label" for="my_model-3">C</label>
+                </div>
+            </div>',
+            $this->bladeView(
+                '<x-bs::form.field name="my_model" type="radio" :options="$options" :value="$value" ' . $blade . '>My Model</x-bs::form.field>',
+                data: [
+                    'options' => [
+                        1 => 'A',
+                        2 => 'B',
+                        3 => 'C',
+                    ],
+                    'value' => 2,
                 ]
             )
         );

--- a/tests/Feature/Form/FormField/Type/RangeTest.php
+++ b/tests/Feature/Form/FormField/Type/RangeTest.php
@@ -3,9 +3,12 @@
 namespace Portavice\Bladestrap\Tests\Feature\Form\FormField\Type;
 
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
+use Portavice\Bladestrap\Tests\Traits\TestsBooleanAttributes;
 
 class RangeTest extends ComponentTestCase
 {
+    use TestsBooleanAttributes;
+
     public function testRangeRendersCorrectly(): void
     {
         $expectedHtml = '<div class="mb-3">
@@ -16,6 +19,26 @@ class RangeTest extends ComponentTestCase
             $expectedHtml,
             $this->bladeView(
                 '<x-bs::form.field name="my_range" type="range" :value="$value" min="0" max="10">My range</x-bs::form.field>',
+                data: [
+                    'value' => 2,
+                ]
+            )
+        );
+    }
+
+    /**
+     * @dataProvider booleanFormFieldAttributes
+     */
+    public function testRangeWithBooleanAttributesRendersCorrectly(string $html, string $blade): void
+    {
+        $expectedHtml = '<div class="mb-3">
+                <label for="my_range" class="form-label">My range</label>
+                <input id="my_range" name="my_range" type="range" value="2" class="form-range" ' . $html . '/>
+            </div>';
+        $this->assertBladeRendersToHtml(
+            $expectedHtml,
+            $this->bladeView(
+                '<x-bs::form.field name="my_range" type="range" :value="$value" ' . $html . '>My range</x-bs::form.field>',
                 data: [
                     'value' => 2,
                 ]

--- a/tests/Feature/Form/FormField/Type/SelectTest.php
+++ b/tests/Feature/Form/FormField/Type/SelectTest.php
@@ -6,9 +6,12 @@ use Illuminate\View\ComponentAttributeBag;
 use Portavice\Bladestrap\Support\OptionCollection;
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
 use Portavice\Bladestrap\Tests\SampleData\TestModel;
+use Portavice\Bladestrap\Tests\Traits\TestsBooleanAttributes;
 
 class SelectTest extends ComponentTestCase
 {
+    use TestsBooleanAttributes;
+
     public function testSelectRendersCorrectly(): void
     {
         $expectedHtml = '<div class="mb-3">
@@ -145,5 +148,33 @@ class SelectTest extends ComponentTestCase
                 $htmlWithAttributes,
             ],
         ];
+    }
+
+    /**
+     * @dataProvider booleanFormFieldAttributes
+     */
+    public function testSelectWithBooleanAttributesRendersCorrectly(string $html, string $blade): void
+    {
+        $this->assertBladeRendersToHtml(
+            '<div class="mb-3">
+                <label for="my_model" class="form-label">My Model</label>
+                <select id="my_model" name="my_model" class="form-select" ' . $html . '>
+                    <option value="1">A</option>
+                    <option value="2" selected>B</option>
+                    <option value="3">C</option>
+                </select>
+            </div>',
+            $this->bladeView(
+                '<x-bs::form.field name="my_model" type="select" :options="$options" :value="$value" cast="int" ' . $blade . '>My Model</x-bs::form.field>',
+                data: [
+                    'options' => [
+                        1 => 'A',
+                        2 => 'B',
+                        3 => 'C',
+                    ],
+                    'value' => 2,
+                ]
+            )
+        );
     }
 }

--- a/tests/Feature/Form/FormField/Type/TextareaTest.php
+++ b/tests/Feature/Form/FormField/Type/TextareaTest.php
@@ -3,9 +3,12 @@
 namespace Portavice\Bladestrap\Tests\Feature\Form\FormField\Type;
 
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
+use Portavice\Bladestrap\Tests\Traits\TestsBooleanAttributes;
 
 class TextareaTest extends ComponentTestCase
 {
+    use TestsBooleanAttributes;
+
     public function testTextareaRendersCorrectly(): void
     {
         $this->assertBladeRendersToHtml(
@@ -17,25 +20,17 @@ class TextareaTest extends ComponentTestCase
         );
     }
 
-    public function testRequiredTextareaRendersCorrectly(): void
+    /**
+     * @dataProvider booleanFormFieldAttributes
+     */
+    public function testTextareaWithBooleanAttributesRendersCorrectly(string $html, string $blade): void
     {
         $this->assertBladeRendersToHtml(
             '<div class="mb-3">
                 <label for="text_block" class="form-label">Text</label>
-                <textarea id="text_block" name="text_block" class="form-control" rows="5" required></textarea>
+                <textarea id="text_block" name="text_block" class="form-control" rows="5" ' . $html . '></textarea>
             </div>',
-            '<x-bs::form.field name="text_block" type="textarea" value="" rows="5" :required="true">Text</x-bs::form.field>'
-        );
-    }
-
-    public function testDisabledTextareaRendersCorrectly(): void
-    {
-        $this->assertBladeRendersToHtml(
-            '<div class="mb-3">
-                <label for="text_block" class="form-label">Text</label>
-                <textarea id="text_block" name="text_block" class="form-control" disabled>DefaultText</textarea>
-            </div>',
-            '<x-bs::form.field name="text_block" type="textarea" value="DefaultText" :disabled="true">Text</x-bs::form.field>'
+            '<x-bs::form.field name="text_block" type="textarea" value="" rows="5" ' . $blade . '>Text</x-bs::form.field>'
         );
     }
 }

--- a/tests/Traits/TestsBooleanAttributes.php
+++ b/tests/Traits/TestsBooleanAttributes.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Portavice\Bladestrap\Tests\Traits;
+
+trait TestsBooleanAttributes
+{
+    public static function booleanFormFieldAttributes(): array
+    {
+        return [
+            ['disabled', ':disabled="true"'],
+            ['disabled readonly', ':disabled="true" :readonly="true"'],
+            ['disabled readonly', ':readonly="true" :disabled="true"'],
+            ['readonly', ':readonly="true"'],
+            ['required', ':required="true"'],
+        ];
+    }
+}


### PR DESCRIPTION
This PR fixes that
- `:disabled="true"` did not work for checkboxes, radios, and switches.
- `:readonly="true"` did not work for checkboxes, radios, selects, and switches.
- `:disabled="true"` did not work for checkboxes, radios, and switches.