### PR TITLE
Rename helper class to Options, fix cast, change order of arguments of append and prepend

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,16 +238,16 @@ Radio buttons, checkboxes and selects need a `:options` attribute providing an i
 - an `Illuminate\Support\Collection`, such as 
   - `:options="User::query()->pluck('name', 'id')"`
   - or `:options="User::query()->pluck('name', 'id')->prepend(__('all'), '')"`
-- a `Portavice\Bladestrap\Support\OptionCollection` which allows to set custom attributes for each option.
+- a `Portavice\Bladestrap\Support\Options` which allows to set custom attributes for each option.
   For checkboxes, radios and switches, custom attributes prefixed with `check-container-` or `check-label-` are applied to the `.form-check` or `.form-check-label` respectively.
 
-An `Portavice\Bladestrap\Support\OptionCollection` can be used to easily create an iterable based on
+An `Portavice\Bladestrap\Support\Options` can be used to easily create an iterable based on
 - an `array`
   ```PHP
-  use Portavice\Bladestrap\Support\OptionCollection;
+  use Portavice\Bladestrap\Support\Options;
 
   // Array with custom attributes
-  OptionCollection::fromArray(
+  Options::fromArray(
         [
             1 => 'One',
             2 => 'Two',
@@ -259,39 +259,39 @@ An `Portavice\Bladestrap\Support\OptionCollection` can be used to easily create 
   ```
 - an `enum` implementing the [BackedEnum interface](https://www.php.net/manual/de/class.backedenum.php)
   ```PHP
-  use Portavice\Bladestrap\Support\OptionCollection;
+  use Portavice\Bladestrap\Support\Options;
 
   // All enum cases with labels based on the value
-  OptionCollection::fromEnum(MyEnum::class);
+  Options::fromEnum(MyEnum::class);
 
   // ... with labels based on the name
-  OptionCollection::fromEnum(MyEnum::class, 'name');
+  Options::fromEnum(MyEnum::class, 'name');
 
   // ... with labels based on the result of the myMethod function
-  OptionCollection::fromEnum(MyEnum::class, 'myMethod');
+  Options::fromEnum(MyEnum::class, 'myMethod');
 
   // Only a subset of enum cases
-  OptionCollection::fromEnum([MyEnum::Case1, MyEnum::Case2]);
+  Options::fromEnum([MyEnum::Case1, MyEnum::Case2]);
   ```
 - an `array` or `Illuminate\Database\Eloquent\Collection` of Eloquent models 
   (the primary key becomes the value, label must be defined)
   ```PHP
-  use Portavice\Bladestrap\Support\OptionCollection;
+  use Portavice\Bladestrap\Support\Options;
 
   // Array of models with labels based on a column or accessor
-  OptionCollection::fromModels([$user1, $user2, ...$moreUsers], 'name');
+  Options::fromModels([$user1, $user2, ...$moreUsers], 'name');
 
   // Collection of models with labels based on a column or accessor
-  OptionCollection::fromModels(User::query()->get(), 'name');
+  Options::fromModels(User::query()->get(), 'name');
 
   // ... with labels based on a Closure
-  OptionCollection::fromModels(
+  Options::fromModels(
       User::query()->get(),
       static fn (User $user) => sprintf('%s (%s)', $user->name, $user->id)
   );
 
   // ... with custom attributes for <option>s using a \Closure defining an ComponentAttributeBag
-  OptionCollection::fromModels(User::query()->get(), 'name', static function (User $user) {
+  Options::fromModels(User::query()->get(), 'name', static function (User $user) {
       return (new ComponentAttributeBag([]))->class([
           'user-option',
           'inactive' => $user->isInactive(),
@@ -299,17 +299,18 @@ An `Portavice\Bladestrap\Support\OptionCollection` can be used to easily create 
   });
 
   // ... with custom attributes for <option>s using a \Closure defining an array of attributes
-  OptionCollection::fromModels(User::query()->get(), 'name', fn (User $user) => [
+  Options::fromModels(User::query()->get(), 'name', fn (User $user) => [
       'data-title' => $user->title,
   ]);
   ```
 
-Additional options can be prepended/appended to an `OptionCollection`:
-```PHP
-use Portavice\Bladestrap\Support\OptionCollection;
+Additional options can be prepended/appended to an `Options`:
 
-$options = OptionCollection::fromModels(User::query()->get(), 'name')
-    ->prepend('', 'all'); // adds at start
+```PHP
+use Portavice\Bladestrap\Support\Options;
+
+$options = Options::fromModels(User::query()->get(), 'name')
+    ->prepend('all', '') // adds an option with empty value at the start
     ->append('last', 'last'); // adds at the end
 ```
 

--- a/resources/views/components/form/field.blade.php
+++ b/resources/views/components/form/field.blade.php
@@ -10,7 +10,7 @@
 
     /**
      * Only for checkbox, select, radio.
-     * @var iterable|Illuminate\Support\Collection|OptionCollection $options
+     * @var iterable|Illuminate\Support\Collection|Options $options
      */
     'options',
 
@@ -42,7 +42,7 @@
     'required' => false,
 ])
 @php
-    use Portavice\Bladestrap\Support\OptionCollection;
+    use Portavice\Bladestrap\Support\Options;
     use Portavice\Bladestrap\Support\ValueHelper;
 
     /** @var \Illuminate\View\ComponentAttributeBag $attributes */
@@ -76,12 +76,12 @@
     if (isset($options)) {
         /** @var \Closure(int|string): \Illuminate\View\ComponentAttributeBag $getAttributesForOption */
         $getAttributesForOption = static function ($optionValue) use ($options) {
-            return $options instanceof OptionCollection
+            return $options instanceof Options
                 ? $options->getAttributes($optionValue)
                 : new \Illuminate\View\ComponentAttributeBag();
         };
 
-        if ($options instanceof OptionCollection) {
+        if ($options instanceof Options) {
             $cast = $cast ?? $options->getCast();
         }
     }

--- a/resources/views/components/form/field.blade.php
+++ b/resources/views/components/form/field.blade.php
@@ -61,8 +61,6 @@
     $dotSyntax = ValueHelper::nameToDotSyntax($name);
     $hasAnyErrors = $errorBag->hasAny($dotSyntax);
 
-    $value = ValueHelper::value($name, $value, $fromQuery, $cast);
-
     /** @var ?\Illuminate\View\ComponentSlot $prependText */
     /** @var ?\Illuminate\View\ComponentSlot $appendText */
     $hasInputGroupContainer = isset($prependText) || isset($appendText);
@@ -87,6 +85,9 @@
             $cast = $cast ?? $options->getCast();
         }
     }
+
+    // Override selected value and apply cast.
+    $value = ValueHelper::value($name, $value, $fromQuery, $cast);
 @endphp
 <div {{ $containerAttributes->class([
     config('bladestrap.form.field.class'),

--- a/src/Support/Options.php
+++ b/src/Support/Options.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\View\ComponentAttributeBag;
 
-class OptionCollection implements \IteratorAggregate
+class Options implements \IteratorAggregate
 {
     /**
      * @var array<int|string,ComponentAttributeBag>
@@ -32,8 +32,8 @@ class OptionCollection implements \IteratorAggregate
     }
 
     public function append(
-        int|string $optionValue,
         int|string $label,
+        int|string $optionValue,
         array|ComponentAttributeBag|null $attributes = null
     ): self {
         $this->options += [$optionValue => $label];
@@ -60,8 +60,8 @@ class OptionCollection implements \IteratorAggregate
     }
 
     public function prepend(
-        int|string $optionValue,
         int|string $label,
+        int|string $optionValue,
         array|ComponentAttributeBag|null $attributes = null
     ): self {
         $this->options = [$optionValue => $label] + $this->options;
@@ -99,15 +99,15 @@ class OptionCollection implements \IteratorAggregate
         array $array,
         \Closure|null $attributeProvider = null
     ): self {
-        $optionCollection = new self($array);
+        $options = new self($array);
 
         if ($attributeProvider instanceof \Closure) {
             foreach ($array as $optionValue => $label) {
-                $optionCollection->setAttributes($optionValue, $attributeProvider($optionValue, $label));
+                $options->setAttributes($optionValue, $attributeProvider($optionValue, $label));
             }
         }
 
-        return $optionCollection;
+        return $options;
     }
 
     /**
@@ -133,18 +133,18 @@ class OptionCollection implements \IteratorAggregate
         foreach ($enumCases as $enumCase) {
             $optionArray[$enumCase->value] = $labelProvider($enumCase);
         }
-        $optionCollection = new self($optionArray);
+        $options = new self($optionArray);
         if (is_int(array_key_first($optionArray))) {
-            $optionCollection->cast = 'int';
+            $options->cast = 'int';
         }
 
         if ($attributeProvider instanceof \Closure) {
             foreach ($enumCases as $enumCase) {
-                $optionCollection->setAttributes($enumCase->value, $attributeProvider($enumCase));
+                $options->setAttributes($enumCase->value, $attributeProvider($enumCase));
             }
         }
 
-        return $optionCollection;
+        return $options;
     }
 
     /**
@@ -181,7 +181,7 @@ class OptionCollection implements \IteratorAggregate
             $labelProvider = static fn ($model) => $model->{$labelProvider};
         }
 
-        $optionCollection = new self(
+        $options = new self(
             $modelCollection->map(static fn ($model) => [
                 'label' => $labelProvider($model),
                 'value' => $model->getKey(),
@@ -189,14 +189,14 @@ class OptionCollection implements \IteratorAggregate
             ->pluck('label', 'value')
             ->toArray()
         );
-        $optionCollection->cast = 'int';
+        $options->cast = 'int';
 
         if ($attributeProvider instanceof \Closure) {
             foreach ($modelCollection as $model) {
-                $optionCollection->setAttributes($model->getKey(), $attributeProvider($model));
+                $options->setAttributes($model->getKey(), $attributeProvider($model));
             }
         }
 
-        return $optionCollection;
+        return $options;
     }
 }

--- a/tests/Feature/Form/FormField/Type/CheckboxTest.php
+++ b/tests/Feature/Form/FormField/Type/CheckboxTest.php
@@ -2,7 +2,7 @@
 
 namespace Portavice\Bladestrap\Tests\Feature\Form\FormField\Type;
 
-use Portavice\Bladestrap\Support\OptionCollection;
+use Portavice\Bladestrap\Support\Options;
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
 use Portavice\Bladestrap\Tests\Traits\TestsBooleanAttributes;
 
@@ -95,7 +95,7 @@ class CheckboxTest extends ComponentTestCase
             </div>
         </div>';
 
-        $options = OptionCollection::fromArray([
+        $options = Options::fromArray([
             1 => 'A',
             2 => 'B',
             3 => 'C',

--- a/tests/Feature/Form/FormField/Type/RadioTest.php
+++ b/tests/Feature/Form/FormField/Type/RadioTest.php
@@ -2,7 +2,7 @@
 
 namespace Portavice\Bladestrap\Tests\Feature\Form\FormField\Type;
 
-use Portavice\Bladestrap\Support\OptionCollection;
+use Portavice\Bladestrap\Support\Options;
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
 use Portavice\Bladestrap\Tests\Traits\TestsBooleanAttributes;
 
@@ -76,7 +76,7 @@ class RadioTest extends ComponentTestCase
             $this->bladeView(
                 '<x-bs::form.field name="my_model" type="radio" :options="$options" :value="$value">My Model</x-bs::form.field>',
                 data: [
-                    'options' => OptionCollection::fromArray(['No', 'Yes'], static fn ($optionValue) => [
+                    'options' => Options::fromArray(['No', 'Yes'], static fn ($optionValue) => [
                         'class' => match ($optionValue) {
                             0 => 'text-danger',
                             1 => 'text-success',

--- a/tests/Feature/Form/FormField/Type/SelectTest.php
+++ b/tests/Feature/Form/FormField/Type/SelectTest.php
@@ -97,7 +97,8 @@ class SelectTest extends ComponentTestCase
                 . '>My Model</x-bs::form.field>',
                 data: [
                     'options' => $optionCollection,
-                    'value' => 2,
+                    // '2' needs int cast.
+                    'value' => '2',
                 ]
             )
         );

--- a/tests/Feature/Form/FormField/Type/SelectTest.php
+++ b/tests/Feature/Form/FormField/Type/SelectTest.php
@@ -3,7 +3,7 @@
 namespace Portavice\Bladestrap\Tests\Feature\Form\FormField\Type;
 
 use Illuminate\View\ComponentAttributeBag;
-use Portavice\Bladestrap\Support\OptionCollection;
+use Portavice\Bladestrap\Support\Options;
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
 use Portavice\Bladestrap\Tests\SampleData\TestModel;
 use Portavice\Bladestrap\Tests\Traits\TestsBooleanAttributes;
@@ -82,7 +82,7 @@ class SelectTest extends ComponentTestCase
     /**
      * @dataProvider attributesProvider
      */
-    public function testSelectWithOptionCollectionRendersCorrectly(OptionCollection $optionCollection, ?string $cast, string $html): void
+    public function testSelectWithOptionsRendersCorrectly(Options $options, ?string $cast, string $html): void
     {
         $this->assertBladeRendersToHtml(
             '<div class="mb-3">
@@ -96,7 +96,7 @@ class SelectTest extends ComponentTestCase
                 . (isset($cast) ? sprintf(' cast="%s"', $cast) : '')
                 . '>My Model</x-bs::form.field>',
                 data: [
-                    'options' => $optionCollection,
+                    'options' => $options,
                     // '2' needs int cast.
                     'value' => '2',
                 ]
@@ -114,22 +114,22 @@ class SelectTest extends ComponentTestCase
                 <option value="4" class="test even" data-short-name="YATM">Yet another test model</option>';
         return [
             [
-                OptionCollection::fromModels(TestModel::samples(), 'short_name'),
+                Options::fromModels(TestModel::samples(), 'short_name'),
                 'int',
                 $defaultHtml,
             ],
             [
-                OptionCollection::fromModels(TestModel::samples(), static fn (TestModel $model) => $model->short_name),
+                Options::fromModels(TestModel::samples(), static fn (TestModel $model) => $model->short_name),
                 'int',
                 $defaultHtml,
             ],
             [
-                OptionCollection::fromModels(TestModel::samples(), static fn (TestModel $model) => $model->short_name),
-                null, // int will be set by OptionCollection::makeModels.
+                Options::fromModels(TestModel::samples(), static fn (TestModel $model) => $model->short_name),
+                null, // int will be set by Options::fromModels.
                 $defaultHtml,
             ],
             [
-                OptionCollection::fromModels(TestModel::samples(), 'name', static function (TestModel $model) {
+                Options::fromModels(TestModel::samples(), 'name', static function (TestModel $model) {
                     return (new ComponentAttributeBag([
                         'data-short-name' => $model->short_name,
                     ]))->class([
@@ -141,7 +141,7 @@ class SelectTest extends ComponentTestCase
                 $htmlWithAttributes,
             ],
             [
-                OptionCollection::fromModels(TestModel::samples(), 'name', fn (TestModel $model) => [
+                Options::fromModels(TestModel::samples(), 'name', fn (TestModel $model) => [
                     'class' => 'test' . ($model->id % 2 === 0 ? ' even' : ''),
                     'data-short-name' => $model->short_name,
                 ]),

--- a/tests/Unit/OptionsTest.php
+++ b/tests/Unit/OptionsTest.php
@@ -5,12 +5,12 @@ namespace Portavice\Bladestrap\Tests\Unit;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\View\ComponentAttributeBag;
 use PHPUnit\Framework\TestCase;
-use Portavice\Bladestrap\Support\OptionCollection;
+use Portavice\Bladestrap\Support\Options;
 use Portavice\Bladestrap\Tests\SampleData\TestIntEnum;
 use Portavice\Bladestrap\Tests\SampleData\TestModel;
 use Portavice\Bladestrap\Tests\SampleData\TestStringEnum;
 
-class OptionCollectionTest extends TestCase
+class OptionsTest extends TestCase
 {
     private static array $testIntArray = [
         1 => 'One',
@@ -19,46 +19,46 @@ class OptionCollectionTest extends TestCase
 
     public function testFromArray(): void
     {
-        $optionCollection = OptionCollection::fromArray(self::$testIntArray);
-        $this->assertEquals(self::$testIntArray, $optionCollection->toArray());
-        $this->assertEquals(new ComponentAttributeBag([]), $optionCollection->getAttributes(1));
+        $options = Options::fromArray(self::$testIntArray);
+        $this->assertEquals(self::$testIntArray, $options->toArray());
+        $this->assertEquals(new ComponentAttributeBag([]), $options->getAttributes(1));
     }
 
     public function testFromArrayWithAttributes(): void
     {
-        $optionCollection = OptionCollection::fromArray(
+        $options = Options::fromArray(
             self::$testIntArray,
             static fn ($k, $v) => new ComponentAttributeBag([
                 'data-value1' => $k + 2,
                 'data-value2' => $k . '_' . $v,
             ])
         );
-        $this->assertEquals(self::$testIntArray, $optionCollection->toArray());
+        $this->assertEquals(self::$testIntArray, $options->toArray());
         $this->assertEquals(new ComponentAttributeBag([
             'data-value1' => 3,
             'data-value2' => '1_One',
-        ]), $optionCollection->getAttributes(1));
+        ]), $options->getAttributes(1));
     }
 
     /**
      * @dataProvider enumIntSamples
      */
-    public function testFromEnumWithInt(array $expectedOptions, OptionCollection $optionCollection): void
+    public function testFromEnumWithInt(array $expectedOptions, Options $options): void
     {
-        $this->assertEquals($expectedOptions, $optionCollection->toArray());
-        $this->assertEquals('int', $optionCollection->getCast());
+        $this->assertEquals($expectedOptions, $options->toArray());
+        $this->assertEquals('int', $options->getCast());
     }
 
     public static function enumIntSamples(): array
     {
         return [
-            [[0, 1, 2], OptionCollection::fromEnum(TestIntEnum::class)],
-            [['Test0', 'Test1', 'Test2'], OptionCollection::fromEnum(TestIntEnum::class, 'name')],
-            [[0, 1, 4], OptionCollection::fromEnum(TestIntEnum::class, 'square')],
-            [[1 => 1, 2 => 4], OptionCollection::fromEnum([TestIntEnum::Test1, TestIntEnum::Test2], 'square')],
+            [[0, 1, 2], Options::fromEnum(TestIntEnum::class)],
+            [['Test0', 'Test1', 'Test2'], Options::fromEnum(TestIntEnum::class, 'name')],
+            [[0, 1, 4], Options::fromEnum(TestIntEnum::class, 'square')],
+            [[1 => 1, 2 => 4], Options::fromEnum([TestIntEnum::Test1, TestIntEnum::Test2], 'square')],
             [
                 [0 => 'Really Test0', 2 => 'Test2'],
-                OptionCollection::fromEnum(
+                Options::fromEnum(
                     [TestIntEnum::Test0, TestIntEnum::Test2],
                     static fn (TestIntEnum $case) => match ($case) {
                         TestIntEnum::Test0 => 'Really Test0',
@@ -72,24 +72,24 @@ class OptionCollectionTest extends TestCase
     /**
      * @dataProvider enumStringSamples
      */
-    public function testFromEnumWithString(array $expectedOptions, OptionCollection $optionCollection): void
+    public function testFromEnumWithString(array $expectedOptions, Options $options): void
     {
-        $this->assertEquals($expectedOptions, $optionCollection->toArray());
-        $this->assertNull($optionCollection->getCast());
+        $this->assertEquals($expectedOptions, $options->toArray());
+        $this->assertNull($options->getCast());
     }
 
     public function testFromEnumWithModelFails(): void
     {
         $this->expectException(\BadMethodCallException::class);
         $this->expectExceptionMessage('Enum expected, but '. TestModel::class. ' found');
-        OptionCollection::fromEnum(TestModel::class);
+        Options::fromEnum(TestModel::class);
     }
 
     public static function enumStringSamples(): array
     {
         return [
-            [['Test1' => 'Test1', 'Test2' => 'Test2'], OptionCollection::fromEnum(TestStringEnum::class)],
-            [['Test1' => '1', 'Test2' => '2'], OptionCollection::fromEnum(TestStringEnum::class, 'getSuffix')],
+            [['Test1' => 'Test1', 'Test2' => 'Test2'], Options::fromEnum(TestStringEnum::class)],
+            [['Test1' => '1', 'Test2' => '2'], Options::fromEnum(TestStringEnum::class, 'getSuffix')],
         ];
     }
 
@@ -99,19 +99,19 @@ class OptionCollectionTest extends TestCase
     public function testFromModels(array|Collection $testModels, array $testModelsIdToName): void
     {
         // With column.
-        $optionCollection = OptionCollection::fromModels($testModels, 'name');
-        $this->assertEquals($testModelsIdToName, $optionCollection->toArray());
+        $options = Options::fromModels($testModels, 'name');
+        $this->assertEquals($testModelsIdToName, $options->toArray());
 
         // With accessor.
-        $optionCollection = OptionCollection::fromModels($testModels, 'display_name');
+        $options = Options::fromModels($testModels, 'display_name');
         $this->assertEquals([
             1 => 'Test model (TM)',
             2 => 'Another test model (ATM)',
             4 => 'Yet another test model (YATM)',
-        ], $optionCollection->toArray());
+        ], $options->toArray());
 
         // With \Closure.
-        $optionCollection = OptionCollection::fromModels(
+        $options = Options::fromModels(
             $testModels,
             static fn (TestModel $model) => sprintf('%s (ID %s)', $model->name, $model->id)
         );
@@ -119,7 +119,7 @@ class OptionCollectionTest extends TestCase
             1 => 'Test model (ID 1)',
             2 => 'Another test model (ID 2)',
             4 => 'Yet another test model (ID 4)',
-        ], $optionCollection->toArray());
+        ], $options->toArray());
     }
 
     /**
@@ -127,7 +127,7 @@ class OptionCollectionTest extends TestCase
      */
     public function testFromModelsWithAttributes(array|Collection $testModels, array $testModelsIdToName): void
     {
-        $optionCollection = OptionCollection::fromModels($testModels, 'name', static function (TestModel $model) {
+        $options = Options::fromModels($testModels, 'name', static function (TestModel $model) {
             $attributes = new ComponentAttributeBag([
                 'data-short-name' => $model->short_name,
             ]);
@@ -140,29 +140,29 @@ class OptionCollectionTest extends TestCase
 
             return $attributes;
         });
-        $this->assertEquals($testModelsIdToName, $optionCollection->toArray());
+        $this->assertEquals($testModelsIdToName, $options->toArray());
 
         $this->assertEquals(new ComponentAttributeBag([
             'data-short-name' => 'TM',
             'data-is-first' => 'true',
-        ]), $optionCollection->getAttributes(1));
+        ]), $options->getAttributes(1));
         $this->assertEquals(new ComponentAttributeBag([
             'data-short-name' => 'ATM',
-        ]), $optionCollection->getAttributes(2));
+        ]), $options->getAttributes(2));
 
-        $optionCollection = OptionCollection::fromModels($testModels, 'name', static function (TestModel $model) {
+        $options = Options::fromModels($testModels, 'name', static function (TestModel $model) {
             return (new ComponentAttributeBag([]))->class([
                 'test',
                 'odd' => $model->id % 2 === 1,
             ]);
         });
-        $this->assertEquals($testModelsIdToName, $optionCollection->toArray());
+        $this->assertEquals($testModelsIdToName, $options->toArray());
         $this->assertEquals(new ComponentAttributeBag([
             'class' => 'test odd',
-        ]), $optionCollection->getAttributes(1));
+        ]), $options->getAttributes(1));
         $this->assertEquals(new ComponentAttributeBag([
             'class' => 'test',
-        ]), $optionCollection->getAttributes(2));
+        ]), $options->getAttributes(2));
     }
 
     public static function modelProvider(): array
@@ -182,64 +182,64 @@ class OptionCollectionTest extends TestCase
 
     public function testAddAttributes(): void
     {
-        $optionCollection = OptionCollection::fromArray(self::$testIntArray);
-        $optionCollection->addAttributes(1, ['data-value1' => 42]);
-        $optionCollection->addAttributes(1, ['data-value2' => 43]);
+        $options = Options::fromArray(self::$testIntArray);
+        $options->addAttributes(1, ['data-value1' => 42]);
+        $options->addAttributes(1, ['data-value2' => 43]);
         $this->assertEquals([
             'data-value1' => 42,
             'data-value2' => 43,
-        ], $optionCollection->getAttributes(1)->getAttributes());
+        ], $options->getAttributes(1)->getAttributes());
     }
 
     public function testAppendAttributes(): void
     {
-        $optionCollection = OptionCollection::fromArray(self::$testIntArray);
-        $optionCollection->append('', 'all');
+        $options = Options::fromArray(self::$testIntArray);
+        $options->append('all', '');
 
         $this->assertEquals([
             1 => 'One',
             2 => 'Two',
             '' => 'all',
-        ], $optionCollection->toArray());
+        ], $options->toArray());
 
-        $optionCollection->append(3, 'Three', ['class' => 'test']);
+        $options->append('Three', 3, ['class' => 'test']);
         $this->assertEquals([
             '' => 'all',
             1 => 'One',
             2 => 'Two',
             3 => 'Three',
-        ], $optionCollection->toArray());
-        $this->assertEquals(new ComponentAttributeBag(['class' => 'test']), $optionCollection->getAttributes(3));
+        ], $options->toArray());
+        $this->assertEquals(new ComponentAttributeBag(['class' => 'test']), $options->getAttributes(3));
     }
 
     public function testPrependAttributes(): void
     {
-        $optionCollection = OptionCollection::fromArray(self::$testIntArray)
-            ->prepend('', 'all');
+        $options = Options::fromArray(self::$testIntArray)
+            ->prepend('all', '');
 
         $this->assertEquals([
             '' => 'all',
             1 => 'One',
             2 => 'Two',
-        ], $optionCollection->toArray());
+        ], $options->toArray());
 
-        $optionCollection->prepend(3, 'Three', ['class' => 'test']);
+        $options->prepend('Three', 3, ['class' => 'test']);
         $this->assertEquals([
             3 => 'Three',
             '' => 'all',
             1 => 'One',
             2 => 'Two',
-        ], $optionCollection->toArray());
-        $this->assertEquals(new ComponentAttributeBag(['class' => 'test']), $optionCollection->getAttributes(3));
+        ], $options->toArray());
+        $this->assertEquals(new ComponentAttributeBag(['class' => 'test']), $options->getAttributes(3));
     }
 
     public function testSetAttributes(): void
     {
-        $optionCollection = OptionCollection::fromArray(self::$testIntArray)
+        $options = Options::fromArray(self::$testIntArray)
             ->setAttributes(1, new ComponentAttributeBag(['data-value1' => 42]))
             ->setAttributes(1, ['data-value2' => 43]);
         $this->assertEquals([
             'data-value2' => 43,
-        ], $optionCollection->getAttributes(1)->getAttributes());
+        ], $options->getAttributes(1)->getAttributes());
     }
 }


### PR DESCRIPTION
- Rename `OptionCollection` to `Options`
- Fix casts set by `Options::fromModels` and `Optons::fromEnum helper`
- Change order of arguments of `append` and `prepend` for methods compliance with the equally named methods of Laravel's `\Illuminate\Support\Collection` allowing easier refactoring if one started with `User::query()->pluck('name', 'id')->prepend('all', '')` and wants to switch to `Options` for attributes definition etc.