### PR TITLE
Add Options::one helper, allow HTML within labels of options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Components for buttons, groups, and toolbars
 - Components for dropdowns
 - Components for forms and their fields
+  - Support all types of `<input>`s, `<textarea>`, and `<select>`s
+  - Options for `<input type="checkbox">`, `<input type="radio">`, and `<option>`s`<select>`:
+    - Set HTML attributes (e.g. classes or data attributes)
+    - Allow HTML for labels
   - Prefill values with old values or from query parameters
   - Show feedback in case of errors
-  - Set HTML attributes for `<option>`s within a `<select>`
 - Components for list groups and their items

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Radio buttons, checkboxes and selects need a `:options` attribute providing an i
   - or `:options="User::query()->pluck('name', 'id')->prepend(__('all'), '')"`
 - a `Portavice\Bladestrap\Support\Options` which allows to set custom attributes for each option.
   For checkboxes, radios and switches, custom attributes prefixed with `check-container-` or `check-label-` are applied to the `.form-check` or `.form-check-label` respectively.
+  If labels contain HTML, set `:allow-html="true"`.
 
 An `Portavice\Bladestrap\Support\Options` can be used to easily create an iterable based on
 - an `array`
@@ -328,13 +329,16 @@ $options = Options::fromModels(User::query()->get(), 'name')
 
 **Single** checkbox (just one option):
 ```HTML
-<x-bs::form.field id="my_field_name" name="my_field_name[]" type="checkbox" :options="[1 => 'Option enabled']"
+<x-bs::form.field id="my_field_name" type="checkbox" :options="[1 => 'Option enabled']"
+                  :value="$value">{{ __('My label') }}</x-bs::form.field>
+<x-bs::form.field id="my_field_name" type="checkbox" :allow-html="true"
+                  :options="Options::one('Option <strong>with HTML</strong> enabled')"
                   :value="$value">{{ __('My label') }}</x-bs::form.field>
 ```
 
 **Select** (allows to select one of multiple values):
 ```HTML
-<x-bs::form.field id="my_field_name" type="select" :options="$options"
+<x-bs::form.field name="my_field_name" type="select" :options="$options"
                   :value="$value">{{ __('My label') }}</x-bs::form.field>
 ```
 

--- a/resources/views/components/form/field.blade.php
+++ b/resources/views/components/form/field.blade.php
@@ -14,6 +14,12 @@
      */
     'options',
 
+    /**
+     * Only affects labels of options.
+     * @var bool $allowHtml
+     */
+    'allowHtml' => false,
+
     /** @var ?string $cast */
     'cast' => null,
 
@@ -23,7 +29,7 @@
      */
     'value' => null,
 
-    /*
+    /**
      * If enabled, value is extracted from the query parameter of the URL.
      * @var bool $fromQuery
      */
@@ -155,7 +161,7 @@
                                 ]) }} @checked(ValueHelper::isActive($optionValue, $value)) @disabled($disabled) @readonly($readonly) @required($required)/>
                             <label @class([
                                 'form-check-label',
-                            ]) for="{{ $optionId }}">{{ $optionLabel }}</label>
+                            ]) for="{{ $optionId }}">@if($allowHtml){!! $optionLabel !!}@else{{ $optionLabel }}@endif</label>
                             @if($loop->last)
                                 <x-bs::form.feedback name="{{ $name }}" :errorBag="$errorBag" :showSubErrors="true"/>
                             @endif

--- a/src/Support/Options.php
+++ b/src/Support/Options.php
@@ -199,4 +199,13 @@ class Options implements \IteratorAggregate
 
         return $options;
     }
+
+    public static function one(
+        int|string $label,
+        array|ComponentAttributeBag|null $attributes = null
+    ): self {
+        $options = (new self([]))->prepend($label, 1, $attributes);
+        $options->cast = 'int';
+        return $options;
+    }
 }

--- a/tests/Feature/Form/FormField/Type/CheckboxTest.php
+++ b/tests/Feature/Form/FormField/Type/CheckboxTest.php
@@ -137,13 +137,16 @@ class CheckboxTest extends ComponentTestCase
         );
     }
 
-    public function testSimpleCheckboxRendersCorrectly(): void
+    /**
+     * @dataProvider singleOptions
+     */
+    public function testSingleCheckboxRendersCorrectly(array|Options $options): void
     {
         $expectedHtml = static fn ($additionalHtml) => '<div class="mb-3">
             <label for="setting_enabled" class="form-label">Setting</label>
             <div class="form-check">
                 <input id="setting_enabled-1" name="setting_enabled" type="checkbox" value="1" class="form-check-input"' . $additionalHtml . '/>
-            <label class="form-check-label" for="setting_enabled-1">Option enabled</label>
+                <label class="form-check-label" for="setting_enabled-1">Option enabled</label>
             </div>
         </div>';
         $this->assertBladeRendersToHtml(
@@ -151,9 +154,7 @@ class CheckboxTest extends ComponentTestCase
             $this->bladeView(
                 '<x-bs::form.field name="setting_enabled" type="checkbox" :options="$options" :value="$value">Setting</x-bs::form.field>',
                 data: [
-                    'options' => [
-                        1 => 'Option enabled',
-                    ],
+                    'options' => $options,
                     'value' => 1,
                 ]
             )
@@ -163,9 +164,65 @@ class CheckboxTest extends ComponentTestCase
             $this->bladeView(
                 '<x-bs::form.field name="setting_enabled" type="checkbox" :options="$options" :value="$value">Setting</x-bs::form.field>',
                 data: [
-                    'options' => [
-                        1 => 'Option enabled',
-                    ],
+                    'options' => $options,
+                    'value' => 0,
+                ]
+            )
+        );
+    }
+
+    public static function singleOptions(): array
+    {
+        return [
+            [1 => 'Option enabled'],
+            Options::one('Option enabled'),
+        ];
+    }
+
+    public function testSingleCheckboxWithOptionsRendersCorrectly(): void
+    {
+        $html = 'I accept the <a class="alert-link" href="https://localhost/terms/" target="_blank">general terms and conditions</a>';
+        $expectedHtml = static fn ($additionalHtml, $label) => '<div class="mb-3">
+            <label for="setting_enabled" class="form-label">Setting</label>
+            <div class="form-check">
+                <input id="setting_enabled-1" name="setting_enabled" type="checkbox" value="1" class="form-check-input"' . $additionalHtml . '/>
+                <label class="form-check-label" for="setting_enabled-1">' . $label . '</label>
+            </div>
+        </div>';
+        $data = [
+            'options' => Options::one($html),
+            'value' => 1,
+        ];
+        $this->assertBladeRendersToHtml(
+            $expectedHtml(' checked', $html),
+            $this->bladeView(
+                '<x-bs::form.field name="setting_enabled" type="checkbox" :options="$options" :value="$value" :allow-html="true">Setting</x-bs::form.field>',
+                data: $data
+            )
+        );
+
+        // Without allow-html, htmlspecialchars is applied on the label.
+        $this->assertBladeRendersToHtml(
+            $expectedHtml('', 'I accept the &lt;a class=&quot;alert-link&quot; href=&quot;https://localhost/terms/&quot; target=&quot;_blank&quot;&gt;general terms and conditions&lt;/a&gt;'),
+            $this->bladeView(
+                '<x-bs::form.field name="setting_enabled" type="checkbox" :options="$options">Setting</x-bs::form.field>',
+                data: $data
+            )
+        );
+
+        // Attributes are supported as well.
+        $this->assertBladeRendersToHtml(
+            '<div class="mb-3">
+            <label for="setting_enabled" class="form-label">Setting</label>
+            <div class="form-check">
+                <input id="setting_enabled-1" name="setting_enabled" type="checkbox" value="1" class="form-check-input test"/>
+                <label class="form-check-label" for="setting_enabled-1">' . $html . '</label>
+            </div>
+        </div>',
+            $this->bladeView(
+                '<x-bs::form.field name="setting_enabled" type="checkbox" :options="$options" :value="$value" :allow-html="true">Setting</x-bs::form.field>',
+                data: [
+                    'options' => Options::one($html, ['class' => 'test']),
                     'value' => 0,
                 ]
             )

--- a/tests/Feature/Form/FormField/Type/CheckboxTest.php
+++ b/tests/Feature/Form/FormField/Type/CheckboxTest.php
@@ -174,8 +174,8 @@ class CheckboxTest extends ComponentTestCase
     public static function singleOptions(): array
     {
         return [
-            [1 => 'Option enabled'],
-            Options::one('Option enabled'),
+            [[1 => 'Option enabled']],
+            [Options::one('Option enabled')],
         ];
     }
 

--- a/tests/Unit/OptionsTest.php
+++ b/tests/Unit/OptionsTest.php
@@ -180,6 +180,15 @@ class OptionsTest extends TestCase
         ];
     }
 
+    public function testOne(): void
+    {
+        $options = Options::one('I accept.', [
+            'data-value' => 'accepted',
+        ]);
+        $this->assertEquals([1 => 'I accept.'], $options->toArray());
+        $this->assertEquals(new ComponentAttributeBag(['data-value' => 'accepted']), $options->getAttributes(1));
+    }
+
     public function testAddAttributes(): void
     {
         $options = Options::fromArray(self::$testIntArray);


### PR DESCRIPTION
- Add `Options::one` helper
- Allow HTML within labels of options via `:allow-html="true"`