### PR TITLE
Support input groups with without automatic wrapping into a `<label>` container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Support input groups with without automatic wrapping into a `<label>` container
+
 ### Fixed
 - Layout of input groups with validation errors
 - Avoid any visible output for form fields of `type="hidden"`

--- a/README.md
+++ b/README.md
@@ -368,6 +368,17 @@ which makes an [input group](https://getbootstrap.com/docs/5.3/forms/input-group
 </x-bs::form.field>
 ```
 
+By default, the appended/prepended text is wrapped within a `<label> class="input-group-text"` associated with the field.
+To avoid this, set `:container="false"` attribute on the slot which allows to define to add buttons for example:
+```HTML
+<x-bs::form.field name="file" type="file">
+    File
+    <x-slot:appendText>
+        <x-bs::button.link variant="primary" href="test.pdf">Download current file</x-bs::button.link>
+    </x-slot:appendText>
+</x-bs::form.field>'
+```
+
 #### Hints
 `<x-slot:hint>` can be used to add a [text](https://getbootstrap.com/docs/5.3/forms/form-control/#form-text) with custom hints (`.form-text`) below the field,
 which will be automatically referenced via `aria-describedby` by the input:

--- a/resources/views/components/form/field.blade.php
+++ b/resources/views/components/form/field.blade.php
@@ -125,7 +125,17 @@
             ])>
         @endif
             @isset($prependText)
-                <label for="{{ $id ?? $name }}" {{ $prependText->attributes->class(['input-group-text']) }}>{{ $prependText }}</label>
+                @if($prependText->attributes->get('container', true) === false)
+                    {{ $prependText }}
+                @else
+                    <label {{ $prependText->attributes
+                        ->class([
+                            'input-group-text',
+                        ])
+                        ->merge([
+                            'for' => $id ?? $name,
+                        ]) }}>{{ $prependText }}</label>
+                @endif
             @endisset
             @switch($type)
                 @case('checkbox')
@@ -241,8 +251,18 @@
                             'value' => $value,
                         ]) }} @disabled($disabled) @readonly($readonly) @required($required)/>
             @endswitch
-            @isset($appendText){{-- avoid whitespace
-                --}}<label for="{{ $id ?? $name }}" {{ $appendText->attributes->class(['input-group-text']) }}>{{ $appendText }}</label>
+            @isset($appendText)
+                @if($appendText->attributes->get('container', true) === false)
+                    {{ $appendText }}
+                @else
+                    <label {{ $appendText->attributes
+                        ->class([
+                            'input-group-text',
+                        ])
+                        ->merge([
+                            'for' => $id ?? $name,
+                        ]) }}>{{ $appendText }}</label>
+                @endif
             @endisset
             @if($showFeedback)
                 <x-bs::form.feedback name="{{ $name }}" :errorBag="$errorBag"/>

--- a/src/Support/Options.php
+++ b/src/Support/Options.php
@@ -93,7 +93,7 @@ class Options implements \IteratorAggregate
 
     /**
      * @param array<int|string,int|string> $array
-     * @param ?\Closure(<int|string>,int|string): ComponentAttributeBag $attributeProvider
+     * @param ?\Closure(int|string,int|string): ComponentAttributeBag $attributeProvider
      */
     public static function fromArray(
         array $array,

--- a/tests/Feature/Form/FormField/FormFieldTest.php
+++ b/tests/Feature/Form/FormField/FormFieldTest.php
@@ -52,42 +52,6 @@ class FormFieldTest extends ComponentTestCase
         );
     }
 
-    public function testFieldWithAppendedTextRendersCorrectly(): void
-    {
-        $this->assertBladeRendersToHtml(
-            '<div class="mb-3">
-                <label for="price" class="form-label">Price</label>
-                <div class="input-group">
-                    <input id="price" name="price" type="number" class="form-control" min="0.01" step="0.01"/>
-                    <label for="price" class="input-group-text fw-bold">€</label>
-                </div>
-            </div>',
-            '<x-bs::form.field name="price" type="number" min="0.01" step="0.01">
-                Price
-                <x-slot:appendText class="fw-bold">€</x-slot>
-            </x-bs::form.field>'
-        );
-    }
-
-    public function testFieldWithAppendedAndPrependedTextRendersCorrectly(): void
-    {
-        $this->assertBladeRendersToHtml(
-            '<div class="mb-3">
-                <label for="price" class="form-label">Price</label>
-                <div class="input-group">
-                    <label for="price" class="input-group-text">≥</label>
-                    <input id="price" name="price" type="number" class="form-control" min="0.01" step="0.01"/>
-                    <label for="price" class="input-group-text">€</label>
-                </div>
-            </div>',
-            '<x-bs::form.field name="price" type="number" min="0.01" step="0.01">
-                Price
-                <x-slot:prependText>≥</x-slot>
-                <x-slot:appendText>€</x-slot>
-            </x-bs::form.field>'
-        );
-    }
-
     /**
      * @dataProvider booleanFormFieldAttributes
      */

--- a/tests/Feature/Form/FormField/FormFieldWithInputGroupTest.php
+++ b/tests/Feature/Form/FormField/FormFieldWithInputGroupTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Feature\Form\FormField;
+
+use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
+
+class FormFieldWithInputGroupTest extends ComponentTestCase
+{
+    /**
+     * @dataProvider inputGroups
+     */
+    public function testFieldWithInputGroupFromTextCorrectly(string $slots, string $append, string $prepend): void
+    {
+        $this->assertBladeRendersToHtml(
+            '<div class="mb-3">
+                <label for="price" class="form-label">Price</label>
+                <div class="input-group">
+                    ' . $append
+                    . '<input id="price" name="price" type="number" class="form-control" min="0.01" step="0.01"/>'
+                    . $prepend . '
+                </div>
+            </div>',
+            '<x-bs::form.field name="price" type="number" min="0.01" step="0.01">
+                Price
+                ' . $slots . '
+            </x-bs::form.field>'
+        );
+    }
+
+    public static function inputGroups(): array
+    {
+        return [
+            [
+                '<x-slot:prependText>≥</x-slot>',
+                '<label for="price" class="input-group-text">≥</label>' . "\n",
+                '',
+            ],
+            [
+                '<x-slot:appendText>€</x-slot>',
+                '',
+                "\n" .'<label for="price" class="input-group-text">€</label>',
+            ],
+            [
+                '<x-slot:prependText>≥</x-slot>
+                <x-slot:appendText>€</x-slot>',
+                '<label for="price" class="input-group-text">≥</label>' . "\n",
+                "\n" .'<label for="price" class="input-group-text">€</label>',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider inputGroupWithoutContainerForSlot
+     */
+    public function testFieldWithInputGroupContainer(string $slot, string $append, string $prepend): void
+    {
+        $this->assertBladeRendersToHtml(
+            '<div class="mb-3">
+                <label for="file" class="form-label">File</label>
+                <div class="input-group">
+                    ' . $append
+                    . '<input id="file" name="file" type="file" class="form-control"/>'
+                    . $prepend . '
+                </div>
+            </div>',
+            '<x-bs::form.field name="file" type="file">
+                File
+                <x-slot ' . $slot . '>
+                    <x-bs::button.link variant="primary" href="test.pdf">Download current file</x-bs::button.link>
+                </x-slot>
+            </x-bs::form.field>'
+        );
+    }
+
+    public static function inputGroupWithoutContainerForSlot(): array
+    {
+        return [
+            [
+                'name="prependText" :container="false"',
+                '<a class="btn btn-primary" href="test.pdf">Download current file</a>' . "\n",
+                '',
+            ],
+            [
+                'name="appendText" :container="false"',
+                '',
+                "\n" . '<a class="btn btn-primary" href="test.pdf">Download current file</a>',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Currently appendText and prependText slots are wrapped into a `<label>` container. Therefore adding an appended or prepended button causes layout issues.

In addition, the tests for input groups are moved to an own test class and use dataProviders now.