### PR TITLE
Move PHPDoc comments outside of @props block, add more PHPDoc in components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- Move PHPDoc comments outside of @props block
+- Move PHPDoc comments outside of `@props` block
 
 
 ## Version 1.1.1 (2024-01-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Move PHPDoc comments outside of @props block
+
 
 ## Version 1.1.1 (2024-01-05)
 

--- a/resources/views/components/alert.blade.php
+++ b/resources/views/components/alert.blade.php
@@ -9,6 +9,7 @@
      * and any custom variants defined via custom Bootstrap build.
      */
     /** @var bool $dismissible */
+    /** @var \Illuminate\View\ComponentAttributeBag $attributes */
 @endphp
 <div {{ $attributes
     ->class([

--- a/resources/views/components/alert.blade.php
+++ b/resources/views/components/alert.blade.php
@@ -1,14 +1,15 @@
 @props([
+    'variant' => 'info',
+    'dismissible' => false,
+])
+@php
     /**
      * @var string $variant
      * Possible values: primary, secondary, success, danger, warning, info, light, dark
      * and any custom variants defined via custom Bootstrap build.
      */
-    'variant' => 'info',
-
     /** @var bool $dismissible */
-    'dismissible' => false,
-])
+@endphp
 <div {{ $attributes
     ->class([
         'alert',

--- a/resources/views/components/badge.blade.php
+++ b/resources/views/components/badge.blade.php
@@ -7,6 +7,7 @@
      * Possible values: primary, secondary, success, danger, warning, info, light, dark
      * and any custom variants defined via custom Bootstrap build.
      */
+    /** @var \Illuminate\View\ComponentAttributeBag $attributes */
 @endphp
 <span {{ $attributes
     ->class([

--- a/resources/views/components/badge.blade.php
+++ b/resources/views/components/badge.blade.php
@@ -1,11 +1,13 @@
 @props([
+    'variant' => 'primary',
+])
+@php
     /**
      * @var string $variant
      * Possible values: primary, secondary, success, danger, warning, info, light, dark
      * and any custom variants defined via custom Bootstrap build.
      */
-    'variant' => 'primary',
-])
+@endphp
 <span {{ $attributes
     ->class([
         'badge',

--- a/resources/views/components/breadcrumb/item.blade.php
+++ b/resources/views/components/breadcrumb/item.blade.php
@@ -4,6 +4,8 @@
 @php
     /** @var ?string $href */
     $active = !isset($href) || \Portavice\Bladestrap\Support\ValueHelper::isUrl($href);
+
+    /** @var \Illuminate\View\ComponentAttributeBag $attributes */
 @endphp
 <li {{ $attributes
     ->class([

--- a/resources/views/components/breadcrumb/item.blade.php
+++ b/resources/views/components/breadcrumb/item.blade.php
@@ -1,8 +1,8 @@
 @props([
-    /** @var ?string $href */
     'href' => null,
 ])
 @php
+    /** @var ?string $href */
     $active = !isset($href) || \Portavice\Bladestrap\Support\ValueHelper::isUrl($href);
 @endphp
 <li {{ $attributes

--- a/resources/views/components/button/group.blade.php
+++ b/resources/views/components/button/group.blade.php
@@ -3,6 +3,7 @@
 ])
 @php
     /** @var bool $vertical */
+    /** @var \Illuminate\View\ComponentAttributeBag $attributes */
 @endphp
 <div {{ $attributes
     ->class([

--- a/resources/views/components/button/group.blade.php
+++ b/resources/views/components/button/group.blade.php
@@ -1,7 +1,9 @@
 @props([
-    /** @var bool $vertical */
     'vertical' => false,
 ])
+@php
+    /** @var bool $vertical */
+@endphp
 <div {{ $attributes
     ->class([
         $vertical ? 'btn-group-vertical' : 'btn-group',

--- a/resources/views/components/button/index.blade.php
+++ b/resources/views/components/button/index.blade.php
@@ -9,6 +9,7 @@
      * their outline-... variants, and any custom variants defined via custom Bootstrap build.
      */
     /** @var bool $disabled */
+    /** @var \Illuminate\View\ComponentAttributeBag $attributes */
 @endphp
 <button {{ $attributes
     ->class([

--- a/resources/views/components/button/index.blade.php
+++ b/resources/views/components/button/index.blade.php
@@ -1,14 +1,15 @@
 @props([
+    'variant' => 'primary',
+    'disabled' => false,
+])
+@php
     /**
      * @var string $variant
      * Possible values: primary, secondary, success, danger, warning, info, light, dark, link,
      * their outline-... variants, and any custom variants defined via custom Bootstrap build.
      */
-    'variant' => 'primary',
-
     /** @var bool $disabled */
-    'disabled' => false,
-])
+@endphp
 <button {{ $attributes
     ->class([
         'btn',

--- a/resources/views/components/button/link.blade.php
+++ b/resources/views/components/button/link.blade.php
@@ -1,14 +1,15 @@
 @props([
+    'variant' => 'primary',
+    'disabled' => false,
+])
+@php
     /**
      * @var string $variant
      * Possible values: primary, secondary, success, danger, warning, info, light, dark
      * and any custom variants defined via custom Bootstrap build.
      */
-    'variant' => 'primary',
-
     /** @var bool $disabled */
-    'disabled' => false,
-])
+@endphp
 <a {{ $attributes
     ->class([
         'btn',

--- a/resources/views/components/button/link.blade.php
+++ b/resources/views/components/button/link.blade.php
@@ -9,6 +9,7 @@
      * and any custom variants defined via custom Bootstrap build.
      */
     /** @var bool $disabled */
+    /** @var \Illuminate\View\ComponentAttributeBag $attributes */
 @endphp
 <a {{ $attributes
     ->class([

--- a/resources/views/components/button/toolbar.blade.php
+++ b/resources/views/components/button/toolbar.blade.php
@@ -1,3 +1,6 @@
+@php
+    /** @var \Illuminate\View\ComponentAttributeBag $attributes */
+@endphp
 <div {{ $attributes
     ->class([
         'btn-toolbar',

--- a/resources/views/components/dropdown/button.blade.php
+++ b/resources/views/components/dropdown/button.blade.php
@@ -6,10 +6,10 @@
      * @var string $direction
      * Possible values: down, down-center, up, up-center, start, end
      */
-    /** @var \Illuminate\View\ComponentAttributeBag $attributes */
-    /** @var ?\Illuminate\View\ComponentSlot $dropdown */
-
     $containerClass = 'drop' . $direction;
+
+    /** @var ?\Illuminate\View\ComponentSlot $dropdown */
+    /** @var \Illuminate\View\ComponentAttributeBag $attributes */
 @endphp
 <div @class($containerClass)>
     <x-bs::button :attributes="$attributes

--- a/resources/views/components/dropdown/button.blade.php
+++ b/resources/views/components/dropdown/button.blade.php
@@ -1,11 +1,11 @@
 @props([
+    'direction' => 'down',
+])
+@php
     /**
      * @var string $direction
      * Possible values: down, down-center, up, up-center, start, end
      */
-    'direction' => 'down',
-])
-@php
     /** @var \Illuminate\View\ComponentAttributeBag $attributes */
     /** @var ?\Illuminate\View\ComponentSlot $dropdown */
 

--- a/resources/views/components/dropdown/header.blade.php
+++ b/resources/views/components/dropdown/header.blade.php
@@ -1,3 +1,6 @@
+@php
+    /** @var \Illuminate\View\ComponentAttributeBag $attributes */
+@endphp
 <li {{ $attributes
     ->class([
         'dropdown-header',

--- a/resources/views/components/dropdown/item.blade.php
+++ b/resources/views/components/dropdown/item.blade.php
@@ -6,6 +6,8 @@
     /** @var bool $isSubItem */
     /** @var bool $subItems */
     $active = \Portavice\Bladestrap\Support\ValueHelper::isUrl($attributes->get('href'));
+
+    /** @var \Illuminate\View\ComponentAttributeBag $attributes */
 @endphp
 <li>{{-- no whitespace
 --}}<a {{ $attributes

--- a/resources/views/components/dropdown/item.blade.php
+++ b/resources/views/components/dropdown/item.blade.php
@@ -3,6 +3,8 @@
     'subItems' => false,
 ])
 @php
+    /** @var bool $isSubItem */
+    /** @var bool $subItems */
     $active = \Portavice\Bladestrap\Support\ValueHelper::isUrl($attributes->get('href'));
 @endphp
 <li>{{-- no whitespace

--- a/resources/views/components/form/feedback.blade.php
+++ b/resources/views/components/form/feedback.blade.php
@@ -10,6 +10,7 @@
     /** @var \Illuminate\Support\ViewErrorBag $errorBag */
     /** @var bool $showSubErrors */
 
+    /** @var \Illuminate\View\ComponentAttributeBag $attributes */
     $attributes = $attributes->class([
         'invalid-feedback',
     ]);

--- a/resources/views/components/form/feedback.blade.php
+++ b/resources/views/components/form/feedback.blade.php
@@ -1,15 +1,14 @@
 @props([
-    /** @var string $name */
     'name',
-
-    /** @var \Illuminate\Support\ViewErrorBag $errorBag */
     'errorBag' => $errors,
-
-    /** @var bool $showSubErrors */
     'showSubErrors' => false,
 ])
 @php
     use Portavice\Bladestrap\Support\ValueHelper;
+
+    /** @var string $name */
+    /** @var \Illuminate\Support\ViewErrorBag $errorBag */
+    /** @var bool $showSubErrors */
 
     $attributes = $attributes->class([
         'invalid-feedback',

--- a/resources/views/components/form/field.blade.php
+++ b/resources/views/components/form/field.blade.php
@@ -1,55 +1,45 @@
 @props([
-    /** @var ?string $id */
     'id' => null,
-
-    /** @var string $name */
     'name',
-
-    /** @var string $type */
     'type',
-
-    /**
-     * Only for checkbox, select, radio.
-     * @var iterable|Illuminate\Support\Collection|Options $options
-     */
     'options',
-
-    /**
-     * Only affects labels of options.
-     * @var bool $allowHtml
-     */
     'allowHtml' => false,
-
-    /** @var ?string $cast */
     'cast' => null,
-
-    /**
-     * The preset value, may be automatically overwritten by an old() value if old values are present.
-     * @var ?mixed $value
-     */
     'value' => null,
-
-    /**
-     * If enabled, value is extracted from the query parameter of the URL.
-     * @var bool $fromQuery
-     */
     'fromQuery' => false,
-
-    /** @var \Illuminate\Support\ViewErrorBag $errorBag */
     'errorBag' => $errors,
-
-    /** @var bool $disabled */
     'disabled' => false,
-
-    /** @var bool $readonly */
     'readonly' => false,
-
-    /** @var bool $required */
     'required' => false,
 ])
 @php
     use Portavice\Bladestrap\Support\Options;
     use Portavice\Bladestrap\Support\ValueHelper;
+
+    /** @var ?string $id */
+    /** @var string $name */
+    /** @var string $type */
+    /**
+     * Only for checkbox, select, radio.
+     * @var iterable|Illuminate\Support\Collection|Options $options
+     */
+    /**
+     * @var bool $allowHtml
+     * Only affects labels of options.
+     */
+    /** @var ?string $cast */
+    /**
+     * The preset value, may be automatically overwritten by an old() value if old values are present.
+     * @var ?mixed $value
+     */
+    /**
+     * @var bool $fromQuery
+     * If enabled, value is extracted from the query parameter of the URL.
+     */
+    /** @var \Illuminate\Support\ViewErrorBag $errorBag */
+    /** @var bool $disabled */
+    /** @var bool $readonly */
+    /** @var bool $required */
 
     /** @var \Illuminate\View\ComponentAttributeBag $attributes */
     /** @var \Illuminate\View\ComponentAttributeBag $containerAttributes */

--- a/resources/views/components/form/index.blade.php
+++ b/resources/views/components/form/index.blade.php
@@ -3,8 +3,9 @@
 ])
 @php
     /** @string $method */
-
     $isDefaultMethod = in_array($method, ['GET', 'POST']);
+
+    /** @var \Illuminate\View\ComponentAttributeBag $attributes */
 @endphp
 <form method="{{ $isDefaultMethod ? $method : 'POST' }}" {{ $attributes }}>
     @if($method !== 'GET')

--- a/resources/views/components/form/index.blade.php
+++ b/resources/views/components/form/index.blade.php
@@ -1,8 +1,9 @@
 @props([
-    /** @string $method */
     'method' => 'POST',
 ])
 @php
+    /** @string $method */
+
     $isDefaultMethod = in_array($method, ['GET', 'POST']);
 @endphp
 <form method="{{ $isDefaultMethod ? $method : 'POST' }}" {{ $attributes }}>

--- a/resources/views/components/link.blade.php
+++ b/resources/views/components/link.blade.php
@@ -1,23 +1,23 @@
 @props([
+    'variant' => 'primary',
+    'opacity' => null,
+    'opacityHover' => null,
+])
+@php
     /**
      * @var string $variant
      * Possible values: primary, secondary, success, danger, warning, info, light, dark
      * and any custom variants defined via custom Bootstrap build.
      */
-    'variant' => 'primary',
-
     /**
      * @var int|string|null $opacity
      * Possible values: 10, 25, 50, 75, 100
      */
-    'opacity' => null,
-
-     /**
+    /**
      * @var int|string|null $opacityHover
      * Possible values: 10, 25, 50, 75, 100
      */
-    'opacityHover' => null,
-])
+@endphp
 <a {{ $attributes
     ->class([
         'link-' . $variant,

--- a/resources/views/components/link.blade.php
+++ b/resources/views/components/link.blade.php
@@ -17,6 +17,7 @@
      * @var int|string|null $opacityHover
      * Possible values: 10, 25, 50, 75, 100
      */
+    /** @var \Illuminate\View\ComponentAttributeBag $attributes */
 @endphp
 <a {{ $attributes
     ->class([

--- a/resources/views/components/list/index.blade.php
+++ b/resources/views/components/list/index.blade.php
@@ -7,6 +7,7 @@
     /** @var string $container */
     /** @var bool $flush */
     /** @var bool $horizontal */
+    /** @var \Illuminate\View\ComponentAttributeBag $attributes */
 @endphp
 <{{ $container }} {{ $attributes
     ->class([

--- a/resources/views/components/list/index.blade.php
+++ b/resources/views/components/list/index.blade.php
@@ -1,13 +1,13 @@
 @props([
-    /** @var string $container */
     'container' => 'ul',
-
-    /** @var bool $flush */
     'flush' => false,
-
-    /** @var bool $horizontal */
     'horizontal' => false,
 ])
+@php
+    /** @var string $container */
+    /** @var bool $flush */
+    /** @var bool $horizontal */
+@endphp
 <{{ $container }} {{ $attributes
     ->class([
         $horizontal ? 'list-group list-group-horizontal' : 'list-group',

--- a/resources/views/components/list/item.blade.php
+++ b/resources/views/components/list/item.blade.php
@@ -1,20 +1,19 @@
 @props([
-    /** @var string $container */
     'container' => 'li',
-
-    /** @var bool $active */
     'active' => false,
-
-    /** @var bool $disabled */
     'disabled' => false,
-
+    'variant' => null,
+])
+@php
+    /** @var string $container */
+    /** @var bool $active */
+    /** @var bool $disabled */
     /**
      * @var ?string $variant
      * Possible values: primary, secondary, success, danger, warning, info, light, dark
      * and any custom variants defined via custom Bootstrap build.
      */
-    'variant' => null,
-])
+@endphp
 <{{ $container }} {{ $attributes
     ->class([
         'list-group-item',

--- a/resources/views/components/list/item.blade.php
+++ b/resources/views/components/list/item.blade.php
@@ -13,6 +13,7 @@
      * Possible values: primary, secondary, success, danger, warning, info, light, dark
      * and any custom variants defined via custom Bootstrap build.
      */
+    /** @var \Illuminate\View\ComponentAttributeBag $attributes */
 @endphp
 <{{ $container }} {{ $attributes
     ->class([

--- a/resources/views/components/nav/index.blade.php
+++ b/resources/views/components/nav/index.blade.php
@@ -5,6 +5,7 @@
 @php
     /** @var string $container */
     /** @var bool $vertical */
+    /** @var \Illuminate\View\ComponentAttributeBag $attributes */
 @endphp
 <{{ $container }} {{ $attributes->class([
     'nav',

--- a/resources/views/components/nav/index.blade.php
+++ b/resources/views/components/nav/index.blade.php
@@ -1,10 +1,11 @@
 @props([
-    /** @var string $container */
     'container' => 'ul',
-
-    /** @var bool $vertical */
     'vertical' => false,
 ])
+@php
+    /** @var string $container */
+    /** @var bool $vertical */
+@endphp
 <{{ $container }} {{ $attributes->class([
     'nav',
     'flex-column' => $vertical,

--- a/resources/views/components/nav/item.blade.php
+++ b/resources/views/components/nav/item.blade.php
@@ -1,15 +1,15 @@
 @props([
-    /** @var bool $disabled */
+    'direction' => 'down',
     'disabled' => false,
-
+])
+@php
     /**
      * @var string $direction
      * Possible values: down, down-center, up, up-center, start, end
      * May be used only in combination with dropdown slot.
      */
-    'direction' => 'down',
-])
-@php
+    /** @var bool $disabled */
+
     /** @var \Illuminate\View\ComponentAttributeBag $attributes */
     $containerAttributes = $attributes->filterAndTransform('container-');
     $itemAttributes = $attributes->whereDoesntStartWith('container-');


### PR DESCRIPTION
PHPDoc in `@props` block causes HTML comment blocks in the rendered output, so we move them to a `@php` block.