### PR TITLE
Add support for Laravel 11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,16 @@ jobs:
     strategy:
       matrix:
         php: [8.1, 8.2, 8.3]
-        laravel: [10.*]
+        laravel: [11.*, 10.*]
         dependency-version: [prefer-lowest, prefer-stable]
+        include:
+          - laravel: 10.*
+            testbench: ^8.22
+          - laravel: 11.*
+            testbench: ^9.0
+        exclude:
+          - laravel: 11.*
+            php: 8.1
 
     name: Tests P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
@@ -24,7 +32,9 @@ jobs:
           php-version: ${{ matrix.php }}
 
       - name: Install dependencies
-        run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests
         run: composer test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support custom casts for form field values via `Closure`
 - Prepend/append multiple options at once
 - Sort options alphabetically or by user defined function
+- Support Laravel 11
 
 
 ## Version 1.2.0 (2024-03-21)

--- a/composer.json
+++ b/composer.json
@@ -22,15 +22,15 @@
     },
     "require": {
         "php": "^8.1",
-        "illuminate/console": "^10.24",
-        "illuminate/http": "^10.24",
-        "illuminate/support": "^10.24",
-        "illuminate/view": "^10.24"
+        "illuminate/console": "^10.24|^11.0",
+        "illuminate/http": "^10.24|^11.0",
+        "illuminate/support": "^10.24|^11.0",
+        "illuminate/view": "^10.24|^11.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.15",
+        "orchestra/testbench": "^8.22|^9.0",
         "phpunit/phpunit": "^10.4",
-        "portavice/laravel-pint-config": "2.0"
+        "portavice/laravel-pint-config": "^2.0"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
This PR adds support for Laravel 11.* while keeping support for Laravel ^10.24.

Run tests for Laravel 11.* for PHP 8.2 and 8.3 using orchestra/testbench ^9.0.
Tests for Laravel ^10.24 for PHP 8.1, 8.2 and 8.3 still use orchestra/testbench ^8.22.

