### PR TITLE
Migrate PHPUnit tests to use PHP attributes instead of comments, support PHPUnit 11; release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+
+## Version 1.3.0 (2024-05-10)
+
 ### Added
 - Support custom casts for form field values via `Closure`
 - Prepend/append multiple options at once
 - Sort options alphabetically or by user defined function
 - Support Laravel 11
+
+### Changed
+- Migrate PHPUnit tests to use PHP attributes instead of comments, support PHPUnit 11
 
 
 ## Version 1.2.0 (2024-03-21)

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "^8.22|^9.0",
-        "phpunit/phpunit": "^10.4",
+        "phpunit/phpunit": "^10.4|^11.1",
         "portavice/laravel-pint-config": "^2.0"
     },
     "config": {

--- a/tests/Feature/AlertTest.php
+++ b/tests/Feature/AlertTest.php
@@ -2,15 +2,14 @@
 
 namespace Portavice\Bladestrap\Tests\Feature;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Portavice\Bladestrap\Tests\Traits\TestsVariants;
 
 class AlertTest extends ComponentTestCase
 {
     use TestsVariants;
 
-    /**
-     * @dataProvider variants
-     */
+    #[DataProvider('variants')]
     public function testAlertsRenderCorrectly(string $buttonClass, ?string $variant): void
     {
         $this->assertBladeRendersToHtml(
@@ -19,9 +18,7 @@ class AlertTest extends ComponentTestCase
         );
     }
 
-    /**
-     * @dataProvider variants
-     */
+    #[DataProvider('variants')]
     public function testDismissibleAlertsRenderCorrectly(string $buttonClass, ?string $variant): void
     {
         $this->assertBladeRendersToHtml(

--- a/tests/Feature/BadgeTest.php
+++ b/tests/Feature/BadgeTest.php
@@ -2,15 +2,14 @@
 
 namespace Portavice\Bladestrap\Tests\Feature;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Portavice\Bladestrap\Tests\Traits\TestsVariants;
 
 class BadgeTest extends ComponentTestCase
 {
     use TestsVariants;
 
-    /**
-     * @dataProvider variants
-     */
+    #[DataProvider('variants')]
     public function testBadgesRenderCorrectly(string $buttonClass, string $variant): void
     {
         $this->assertBladeRendersToHtml(

--- a/tests/Feature/Button/ButtonLinkTest.php
+++ b/tests/Feature/Button/ButtonLinkTest.php
@@ -2,6 +2,7 @@
 
 namespace Portavice\Bladestrap\Tests\Feature\Button;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
 use Portavice\Bladestrap\Tests\Traits\TestsVariants;
 
@@ -9,9 +10,7 @@ class ButtonLinkTest extends ComponentTestCase
 {
     use TestsVariants;
 
-    /**
-     * @dataProvider variants
-     */
+    #[DataProvider('variants')]
     public function testLinksRenderCorrectly(string $buttonClass, ?string $variant): void
     {
         $this->assertBladeRendersToHtml(
@@ -25,9 +24,7 @@ class ButtonLinkTest extends ComponentTestCase
         );
     }
 
-    /**
-     * @dataProvider variants
-     */
+    #[DataProvider('variants')]
     public function testDisabledLinksRenderCorrectly(string $buttonClass, ?string $variant): void
     {
         /*

--- a/tests/Feature/Button/ButtonTest.php
+++ b/tests/Feature/Button/ButtonTest.php
@@ -2,6 +2,7 @@
 
 namespace Portavice\Bladestrap\Tests\Feature\Button;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
 use Portavice\Bladestrap\Tests\Traits\TestsVariants;
 
@@ -9,9 +10,7 @@ class ButtonTest extends ComponentTestCase
 {
     use TestsVariants;
 
-    /**
-     * @dataProvider variants
-     */
+    #[DataProvider('variants')]
     public function testButtonsRenderCorrectly(string $buttonClass, ?string $variant): void
     {
         $this->assertBladeRendersToHtml(
@@ -25,9 +24,7 @@ class ButtonTest extends ComponentTestCase
         );
     }
 
-    /**
-     * @dataProvider variants
-     */
+    #[DataProvider('variants')]
     public function testDisabledButtonsRenderCorrectly(string $buttonClass, ?string $variant): void
     {
         $this->assertBladeRendersToHtml(

--- a/tests/Feature/Dropdown/DropdownButtonTest.php
+++ b/tests/Feature/Dropdown/DropdownButtonTest.php
@@ -2,6 +2,7 @@
 
 namespace Portavice\Bladestrap\Tests\Feature\Dropdown;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
 use Portavice\Bladestrap\Tests\Traits\TestsVariants;
 
@@ -9,9 +10,7 @@ class DropdownButtonTest extends ComponentTestCase
 {
     use TestsVariants;
 
-    /**
-     * @dataProvider variants
-     */
+    #[DataProvider('variants')]
     public function testDropdownButtonRendersCorrectly(string $buttonClass, ?string $variant): void
     {
         $this->assertBladeRendersToHtml(
@@ -63,9 +62,7 @@ class DropdownButtonTest extends ComponentTestCase
         );
     }
 
-    /**
-     * @dataProvider directions
-     */
+    #[DataProvider('directions')]
     public function testDropdownButtonWithDirectionRendersCorrectly(string $containerClass, ?string $direction): void
     {
         $this->assertBladeRendersToHtml(

--- a/tests/Feature/Form/FormField/FormFieldErrors.php
+++ b/tests/Feature/Form/FormField/FormFieldErrors.php
@@ -2,14 +2,13 @@
 
 namespace Portavice\Bladestrap\Tests\Feature\Form\FormField;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Portavice\Bladestrap\Support\Options;
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
 
 class FormFieldErrors extends ComponentTestCase
 {
-    /**
-     * @dataProvider allTypes
-     */
+    #[DataProvider('allTypes')]
     public function testFormFieldShowsErrors(string $type, string $output): void
     {
         $outputWithErrorMessage = str_replace(
@@ -89,9 +88,7 @@ class FormFieldErrors extends ComponentTestCase
         ];
     }
 
-    /**
-     * @dataProvider typesSupportingInputGroups
-     */
+    #[DataProvider('typesSupportingInputGroups')]
     public function testFormFieldWithInputGroupShowsErrors(string $type, string $output): void
     {
         $this->assertBladeRendersToHtml(

--- a/tests/Feature/Form/FormField/FormFieldTest.php
+++ b/tests/Feature/Form/FormField/FormFieldTest.php
@@ -2,6 +2,7 @@
 
 namespace Portavice\Bladestrap\Tests\Feature\Form\FormField;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
 use Portavice\Bladestrap\Tests\Traits\TestsBooleanAttributes;
 
@@ -52,9 +53,7 @@ class FormFieldTest extends ComponentTestCase
         );
     }
 
-    /**
-     * @dataProvider booleanFormFieldAttributes
-     */
+    #[DataProvider('booleanFormFieldAttributes')]
     public function testFormFieldWithBooleanAttributesRendersCorrectly(string $html, string $blade): void
     {
         $this->assertBladeRendersToHtml(

--- a/tests/Feature/Form/FormField/FormFieldValuesFilledFromOldTest.php
+++ b/tests/Feature/Form/FormField/FormFieldValuesFilledFromOldTest.php
@@ -3,22 +3,19 @@
 namespace Portavice\Bladestrap\Tests\Feature\Form\FormField;
 
 use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
 
 class FormFieldValuesFilledFromOldTest extends ComponentTestCase
 {
-    /**
-     * @dataProvider formDataProvider
-     */
+    #[DataProvider('formDataProvider')]
     public function testFormFieldFilledWithOldValue(array $old, string $html, string $blade, array $data): void
     {
         $this->mockOld($old);
         $this->assertBladeRendersToHtml($html, $this->bladeView($blade, $data));
     }
 
-    /**
-     * @dataProvider formDataProvider
-     */
+    #[DataProvider('formDataProvider')]
     public function testDisabledFormFieldHasValueEvenIfNotInOldValues(array $old): void
     {
         $this->mockOld($old);

--- a/tests/Feature/Form/FormField/FormFieldWithInputGroupTest.php
+++ b/tests/Feature/Form/FormField/FormFieldWithInputGroupTest.php
@@ -2,13 +2,12 @@
 
 namespace Feature\Form\FormField;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
 
 class FormFieldWithInputGroupTest extends ComponentTestCase
 {
-    /**
-     * @dataProvider inputGroups
-     */
+    #[DataProvider('inputGroups')]
     public function testFieldWithInputGroupFromTextCorrectly(string $slots, string $append, string $prepend): void
     {
         $this->assertBladeRendersToHtml(
@@ -49,9 +48,7 @@ class FormFieldWithInputGroupTest extends ComponentTestCase
         ];
     }
 
-    /**
-     * @dataProvider inputGroupWithoutContainerForSlot
-     */
+    #[DataProvider('inputGroupWithoutContainerForSlot')]
     public function testFieldWithInputGroupContainer(string $slot, string $append, string $prepend): void
     {
         $this->assertBladeRendersToHtml(

--- a/tests/Feature/Form/FormField/Type/CheckboxTest.php
+++ b/tests/Feature/Form/FormField/Type/CheckboxTest.php
@@ -2,6 +2,7 @@
 
 namespace Portavice\Bladestrap\Tests\Feature\Form\FormField\Type;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Portavice\Bladestrap\Support\Options;
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
 use Portavice\Bladestrap\Tests\Traits\TestsBooleanAttributes;
@@ -10,9 +11,7 @@ class CheckboxTest extends ComponentTestCase
 {
     use TestsBooleanAttributes;
 
-    /**
-     * @dataProvider checkBoxTypes
-     */
+    #[DataProvider('checkBoxTypes')]
     public function testMultipleCheckboxRendersCorrectly(
         string $componentType,
         string $checkClass,
@@ -71,9 +70,7 @@ class CheckboxTest extends ComponentTestCase
         );
     }
 
-    /**
-     * @dataProvider checkBoxTypes
-     */
+    #[DataProvider('checkBoxTypes')]
     public function testCheckboxWithAttributesRendersCorrectly(
         string $componentType,
         string $checkClass,
@@ -137,9 +134,7 @@ class CheckboxTest extends ComponentTestCase
         );
     }
 
-    /**
-     * @dataProvider singleOptions
-     */
+    #[DataProvider('singleOptions')]
     public function testSingleCheckboxRendersCorrectly(array|Options $options): void
     {
         $expectedHtml = static fn ($additionalHtml) => '<div class="mb-3">
@@ -229,9 +224,7 @@ class CheckboxTest extends ComponentTestCase
         );
     }
 
-    /**
-     * @dataProvider booleanFormFieldAttributes
-     */
+    #[DataProvider('booleanFormFieldAttributes')]
     public function testFormFieldWithBooleanAttributesRendersCorrectly(string $html, string $blade): void
     {
         $this->assertBladeRendersToHtml(

--- a/tests/Feature/Form/FormField/Type/HiddenTest.php
+++ b/tests/Feature/Form/FormField/Type/HiddenTest.php
@@ -2,13 +2,12 @@
 
 namespace Feature\Form\FormField\Type;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
 
 class HiddenTest extends ComponentTestCase
 {
-    /**
-     * @dataProvider hiddenFields
-     */
+    #[DataProvider('hiddenFields')]
     public function testHiddenInputRendersCorrectly(string $blade): void
     {
         $this->assertBladeRendersToHtml(

--- a/tests/Feature/Form/FormField/Type/RadioTest.php
+++ b/tests/Feature/Form/FormField/Type/RadioTest.php
@@ -2,6 +2,7 @@
 
 namespace Portavice\Bladestrap\Tests\Feature\Form\FormField\Type;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Portavice\Bladestrap\Support\Options;
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
 use Portavice\Bladestrap\Tests\Traits\TestsBooleanAttributes;
@@ -88,9 +89,7 @@ class RadioTest extends ComponentTestCase
         );
     }
 
-    /**
-     * @dataProvider booleanFormFieldAttributes
-     */
+    #[DataProvider('booleanFormFieldAttributes')]
     public function testRadioWithBooleanAttributesRendersCorrectly(string $html, string $blade): void
     {
         $this->assertBladeRendersToHtml(

--- a/tests/Feature/Form/FormField/Type/RangeTest.php
+++ b/tests/Feature/Form/FormField/Type/RangeTest.php
@@ -2,6 +2,7 @@
 
 namespace Portavice\Bladestrap\Tests\Feature\Form\FormField\Type;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
 use Portavice\Bladestrap\Tests\Traits\TestsBooleanAttributes;
 
@@ -26,9 +27,7 @@ class RangeTest extends ComponentTestCase
         );
     }
 
-    /**
-     * @dataProvider booleanFormFieldAttributes
-     */
+    #[DataProvider('booleanFormFieldAttributes')]
     public function testRangeWithBooleanAttributesRendersCorrectly(string $html, string $blade): void
     {
         $expectedHtml = '<div class="mb-3">

--- a/tests/Feature/Form/FormField/Type/SelectTest.php
+++ b/tests/Feature/Form/FormField/Type/SelectTest.php
@@ -3,6 +3,7 @@
 namespace Portavice\Bladestrap\Tests\Feature\Form\FormField\Type;
 
 use Illuminate\View\ComponentAttributeBag;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Portavice\Bladestrap\Support\Options;
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
 use Portavice\Bladestrap\Tests\SampleData\TestModel;
@@ -79,9 +80,7 @@ class SelectTest extends ComponentTestCase
         );
     }
 
-    /**
-     * @dataProvider attributesProvider
-     */
+    #[DataProvider('attributesProvider')]
     public function testSelectWithOptionsRendersCorrectly(Options $options, ?string $cast, string $html): void
     {
         $this->assertBladeRendersToHtml(
@@ -151,9 +150,7 @@ class SelectTest extends ComponentTestCase
         ];
     }
 
-    /**
-     * @dataProvider booleanFormFieldAttributes
-     */
+    #[DataProvider('booleanFormFieldAttributes')]
     public function testSelectWithBooleanAttributesRendersCorrectly(string $html, string $blade): void
     {
         $this->assertBladeRendersToHtml(

--- a/tests/Feature/Form/FormField/Type/TextareaTest.php
+++ b/tests/Feature/Form/FormField/Type/TextareaTest.php
@@ -2,6 +2,7 @@
 
 namespace Portavice\Bladestrap\Tests\Feature\Form\FormField\Type;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
 use Portavice\Bladestrap\Tests\Traits\TestsBooleanAttributes;
 
@@ -20,9 +21,7 @@ class TextareaTest extends ComponentTestCase
         );
     }
 
-    /**
-     * @dataProvider booleanFormFieldAttributes
-     */
+    #[DataProvider('booleanFormFieldAttributes')]
     public function testTextareaWithBooleanAttributesRendersCorrectly(string $html, string $blade): void
     {
         $this->assertBladeRendersToHtml(

--- a/tests/Feature/LinkTest.php
+++ b/tests/Feature/LinkTest.php
@@ -2,15 +2,14 @@
 
 namespace Portavice\Bladestrap\Tests\Feature;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Portavice\Bladestrap\Tests\Traits\TestsVariants;
 
 class LinkTest extends ComponentTestCase
 {
     use TestsVariants;
 
-    /**
-     * @dataProvider variants
-     */
+    #[DataProvider('variants')]
     public function testLinksRenderCorrectly(string $linkClass, ?string $variant): void
     {
         $this->assertBladeRendersToHtml(

--- a/tests/Feature/ListTest.php
+++ b/tests/Feature/ListTest.php
@@ -2,15 +2,14 @@
 
 namespace Portavice\Bladestrap\Tests\Feature;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Portavice\Bladestrap\Tests\Traits\TestsVariants;
 
 class ListTest extends ComponentTestCase
 {
     use TestsVariants;
 
-    /**
-     * @dataProvider listVariables
-     */
+    #[DataProvider('listVariables')]
     public function testListGroupRendersCorrectly(string $additionalClasses, string $variables): void
     {
         $this->assertBladeRendersToHtml(
@@ -42,9 +41,7 @@ class ListTest extends ComponentTestCase
         );
     }
 
-    /**
-     * @dataProvider variants
-     */
+    #[DataProvider('variants')]
     public function testListItemsRenderCorrectly(string $additionalClasses, ?string $variant): void
     {
         $this->assertBladeRendersToHtml(

--- a/tests/Feature/Modal/ModalButtonTest.php
+++ b/tests/Feature/Modal/ModalButtonTest.php
@@ -2,6 +2,7 @@
 
 namespace Feature\Modal;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
 use Portavice\Bladestrap\Tests\Traits\TestsVariants;
 
@@ -9,9 +10,7 @@ class ModalButtonTest extends ComponentTestCase
 {
     use TestsVariants;
 
-    /**
-     * @dataProvider variants
-     */
+    #[DataProvider('variants')]
     public function testModalButtonRendersCorrectly(string $buttonClass, ?string $variant): void
     {
         $this->assertBladeRendersToHtml(

--- a/tests/Feature/Modal/ModalTest.php
+++ b/tests/Feature/Modal/ModalTest.php
@@ -2,13 +2,12 @@
 
 namespace Feature\Modal;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
 
 class ModalTest extends ComponentTestCase
 {
-    /**
-     * @dataProvider modalOptions
-     */
+    #[DataProvider('modalOptions')]
     public function testModalRendersOptionsCorrectly(string $blade, string $modalAttributes, string $modalDialogClasses): void
     {
         $this->assertBladeRendersToHtml(
@@ -41,9 +40,7 @@ class ModalTest extends ComponentTestCase
         ];
     }
 
-    /**
-     * @dataProvider fullScreenOptions
-     */
+    #[DataProvider('fullScreenOptions')]
     public function testModalRendersFullScreenOptionsCorrectly(bool|string $fullScreen, string $modalDialogClass): void
     {
         $this->assertBladeRendersToHtml(
@@ -78,9 +75,7 @@ class ModalTest extends ComponentTestCase
         ];
     }
 
-    /**
-     * @dataProvider closeButtonOptions
-     */
+    #[DataProvider('closeButtonOptions')]
     public function testModalRendersCloseButtonCorrectly(string $closeButtonAttributes, string $footer): void
     {
         $this->assertBladeRendersToHtml(
@@ -109,9 +104,7 @@ class ModalTest extends ComponentTestCase
         ];
     }
 
-    /**
-     * @dataProvider slots
-     */
+    #[DataProvider('slots')]
     public function testModalRendersSlotsCorrectly(string $slots, string $header, string $footer): void
     {
         $this->assertBladeRendersToHtml(

--- a/tests/Unit/OptionsTest.php
+++ b/tests/Unit/OptionsTest.php
@@ -4,6 +4,7 @@ namespace Portavice\Bladestrap\Tests\Unit;
 
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\View\ComponentAttributeBag;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Portavice\Bladestrap\Support\Options;
 use Portavice\Bladestrap\Tests\SampleData\TestIntEnum;
@@ -40,9 +41,7 @@ class OptionsTest extends TestCase
         ]), $options->getAttributes(1));
     }
 
-    /**
-     * @dataProvider enumIntSamples
-     */
+    #[DataProvider('enumIntSamples')]
     public function testFromEnumWithInt(array $expectedOptions, Options $options): void
     {
         $this->assertArrayEquals($expectedOptions, $options->toArray());
@@ -69,9 +68,7 @@ class OptionsTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider enumStringSamples
-     */
+    #[DataProvider('enumStringSamples')]
     public function testFromEnumWithString(array $expectedOptions, Options $options): void
     {
         $this->assertArrayEquals($expectedOptions, $options->toArray());
@@ -93,9 +90,7 @@ class OptionsTest extends TestCase
         Options::fromEnum(TestModel::class);
     }
 
-    /**
-     * @dataProvider modelProvider
-     */
+    #[DataProvider('modelProvider')]
     public function testFromModels(array|Collection $testModels, array $testModelsIdToName): void
     {
         // With column.
@@ -122,9 +117,7 @@ class OptionsTest extends TestCase
         ], $options->toArray());
     }
 
-    /**
-     * @dataProvider modelProvider
-     */
+    #[DataProvider('modelProvider')]
     public function testFromModelsWithAttributes(array|Collection $testModels, array $testModelsIdToName): void
     {
         $options = Options::fromModels($testModels, 'name', static function (TestModel $model) {


### PR DESCRIPTION
Use [PHP attributes](https://docs.phpunit.de/en/10.5/attributes.html#dataprovider) instead of comments to avoid warnings with PHPUnit 11