### PR TITLE
Don't override passed values for form fields if fromQuery is enabled, but there is no query parameter with the value

### DIFF
--- a/src/Support/ValueHelper.php
+++ b/src/Support/ValueHelper.php
@@ -71,11 +71,14 @@ class ValueHelper
         $dotSyntax = self::nameToDotSyntax($name);
         $request = self::getRequest();
         if ($fromQuery) {
-            $value = Arr::get(
+            $queryValue = Arr::get(
                 $request->query(),
                 $dotSyntax,
                 Arr::get(self::$defaults, $dotSyntax)
             );
+            if ($queryValue !== null) {
+                $value = $queryValue;
+            }
         }
 
         if (count($request->old(null, [])) > 0) {

--- a/tests/Feature/Form/FormField/FormFieldValuesFilledFromQueryTest.php
+++ b/tests/Feature/Form/FormField/FormFieldValuesFilledFromQueryTest.php
@@ -2,6 +2,7 @@
 
 namespace Portavice\Bladestrap\Tests\Feature\Form\FormField;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Portavice\Bladestrap\Support\ValueHelper;
 use Portavice\Bladestrap\Tests\Feature\ComponentTestCase;
 
@@ -41,6 +42,28 @@ class FormFieldValuesFilledFromQueryTest extends ComponentTestCase
             </div>',
             $this->bladeView('<x-bs::form.field name="test" type="text" :from-query="true">Test</x-bs::form.field>')
         );
+    }
+
+    #[DataProvider('urlsWithValues')]
+    public function testFormFieldFilledFromValueOrQuery(string $url, string $value): void
+    {
+        $this->mockRequest($url);
+
+        $this->assertBladeRendersToHtml(
+            '<div class="mb-3">
+                <label for="test" class="form-label">Test</label>
+                <input id="test" name="test" type="text" value="' . $value . '" class="form-control"/>
+            </div>',
+            $this->bladeView('<x-bs::form.field name="test" type="text" value="default-value" :from-query="true">Test</x-bs::form.field>')
+        );
+    }
+
+    public static function urlsWithValues(): array
+    {
+        return [
+            ['http://localhost', 'default-value'],
+            ['http://localhost?test=another-value', 'another-value'],
+        ];
     }
 
     public function testHasFromQueryWithDefaultAndWithQueryParameters(): void


### PR DESCRIPTION
Currently the value of form field will be overwritten by null for a `<x-bs::form.field :from-query="true">` if the URL does not contain the query parameter. This is unwanted and fixed by this PR.