### PR TITLE
Cast enum and models set as value before comparing whether a value is active

### DIFF
--- a/src/Support/ValueHelper.php
+++ b/src/Support/ValueHelper.php
@@ -2,6 +2,7 @@
 
 namespace Portavice\Bladestrap\Support;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 
@@ -103,6 +104,13 @@ class ValueHelper
 
         if ($cast instanceof \Closure) {
             return $cast($value);
+        }
+
+        if ($value instanceof \BackedEnum) {
+            $value = $value->value;
+        }
+        if ($value instanceof Model) {
+            $value = $value->id;
         }
 
         return match ($cast) {

--- a/tests/Unit/ValueHelperTest.php
+++ b/tests/Unit/ValueHelperTest.php
@@ -5,6 +5,9 @@ namespace Portavice\Bladestrap\Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use Portavice\Bladestrap\Support\ValueHelper;
 use Portavice\Bladestrap\Tests\Feature\Form\FormField\FormFieldValuesFilledFromQueryTest;
+use Portavice\Bladestrap\Tests\SampleData\TestIntEnum;
+use Portavice\Bladestrap\Tests\SampleData\TestModel;
+use Portavice\Bladestrap\Tests\SampleData\TestStringEnum;
 
 class ValueHelperTest extends TestCase
 {
@@ -15,6 +18,18 @@ class ValueHelperTest extends TestCase
         $this->assertEquals('names', ValueHelper::nameToDotSyntax('names[]'));
         $this->assertEquals('names.1', ValueHelper::nameToDotSyntax('names[1]'));
         $this->assertEquals('names.1', ValueHelper::nameToDotSyntax('names[1][]'));
+    }
+
+    public function testCastEnum(): void
+    {
+        $this->assertEquals(2, ValueHelper::castValue(TestIntEnum::Test2, null));
+        $this->assertEquals('Test2', ValueHelper::castValue(TestStringEnum::Test2, null));
+    }
+
+    public function testCastModel(): void
+    {
+        $testModel = TestModel::samples()->random(1)->first();
+        $this->assertEquals($testModel->id, ValueHelper::castValue($testModel, null));
     }
 
     public function testCastValueToBool(): void


### PR DESCRIPTION
This way `->value` can be removed from `<x-bs::form.field name="test" type="radio" :options="Options::fromEnum(MyEnum::class)" :value="MyEnum::ExampleCase->value"/>`.