### PR TITLE
Support PHP 8.4

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -6,11 +6,6 @@ jobs:
   code-style:
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        php: [8.2]
-
     name: Code style
 
     steps:
@@ -20,7 +15,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: 8.4
 
       - name: Install
         run: composer install --prefer-dist --no-interaction

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.1, 8.2, 8.3]
+        php: [8.1, 8.2, 8.3, 8.4]
         laravel: [11.*, 10.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Mark required fields with a `*`
+- Support PHP 8.4
 
 
 ## Version 1.3.0 (2024-05-10)


### PR DESCRIPTION
Add PHP 8.4 to the CI build. No changes necessary for compatibility with the new version.